### PR TITLE
test(openshell): skip when openshell-server isn't deployed

### DIFF
--- a/kagenti/tests/e2e/openshell/test_T0_1_infra_platform.py
+++ b/kagenti/tests/e2e/openshell/test_T0_1_infra_platform.py
@@ -28,9 +28,8 @@ class TestOpenShellGateway:
             p for p in pods if p["metadata"]["name"].startswith("openshell-server")
         ]
 
-        assert len(gateway_pods) > 0, (
-            f"No openshell-server pods found in {gateway_namespace}"
-        )
+        if not gateway_pods:
+            pytest.skip(f"openshell-server not deployed in {gateway_namespace}")
 
         for pod in gateway_pods:
             phase = pod["status"].get("phase", "Unknown")
@@ -46,7 +45,8 @@ class TestOpenShellGateway:
             p for p in pods if p["metadata"]["name"].startswith("openshell-server")
         ]
 
-        assert len(gateway_pods) > 0, "No openshell-server pods found"
+        if not gateway_pods:
+            pytest.skip(f"openshell-server not deployed in {gateway_namespace}")
 
         for pod in gateway_pods:
             name = pod["metadata"]["name"]

--- a/kagenti/tests/e2e/openshell/test_T1_3_sandbox_lifecycle.py
+++ b/kagenti/tests/e2e/openshell/test_T1_3_sandbox_lifecycle.py
@@ -163,6 +163,8 @@ spec:
             GATEWAY_NS,
             "--tail=50",
         )
+        if result.returncode != 0 and "NotFound" in result.stderr:
+            pytest.skip("openshell-server-0 pod not found — openshell not deployed")
         assert result.returncode == 0
         assert (
             "compute driver" in result.stdout.lower()
@@ -283,6 +285,8 @@ class TestSandboxStatusObservability:
             GATEWAY_NS,
             "--tail=20",
         )
+        if result.returncode != 0 and "NotFound" in result.stderr:
+            pytest.skip("openshell-server-0 pod not found — openshell not deployed")
         assert result.returncode == 0, f"Cannot read gateway logs: {result.stderr}"
         assert len(result.stdout) > 0, "Gateway logs are empty"
 

--- a/kagenti/tests/e2e/openshell/test_T1_7_sandbox_connectivity.py
+++ b/kagenti/tests/e2e/openshell/test_T1_7_sandbox_connectivity.py
@@ -39,10 +39,14 @@ class TestGatewayConnectivity:
             if p["metadata"]["name"].startswith("openshell-server")
             and p["status"].get("phase") == "Running"
         ]
-        assert gateway_pods, f"No running openshell-server pod in {SANDBOX_NS}"
+        if not gateway_pods:
+            pytest.skip(f"openshell-server not deployed in {SANDBOX_NS}")
 
     def test_gateway_service_has_endpoints(self):
         """Gateway service has at least one ready endpoint."""
+        svc_check = kubectl_run("get", "svc", "openshell-server", "-n", SANDBOX_NS)
+        if svc_check.returncode != 0:
+            pytest.skip(f"openshell-server service not found in {SANDBOX_NS}")
         result = kubectl_run(
             "get",
             "endpoints",
@@ -59,6 +63,10 @@ class TestGatewayConnectivity:
     def test_gateway_port_forward_reachable(self):
         """Gateway responds to HTTP requests via port-forward."""
         import socket
+
+        svc_check = kubectl_run("get", "svc", "openshell-server", "-n", SANDBOX_NS)
+        if svc_check.returncode != 0:
+            pytest.skip(f"openshell-server service not found in {SANDBOX_NS}")
 
         local_port = find_free_port()
         proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

Replaces hard asserts with `pytest.skip()` in 7 openshell tests when the
gateway pod, service, or logs aren't reachable. Lets the suite run cleanly on
clusters where OpenShell isn't deployed.

## Cluster tested on

`kagenti-hypershift-custom-ocp1` (HyperShift hosted cluster on AWS, OCP
4.20.21, 3-worker NodePool, no OpenShell deployment).

## Kagenti version under test

v0.6.0-rc.13

## Test plan / result

Verified on 2026-06-08 with:

```
uv run pytest kagenti/tests/e2e/ -v --ignore=kagenti/tests/e2e/token_exchange
```

→ **73 passed, 276 skipped, 0 failed** (all 7 affected tests now report SKIPPED
with a clear "openshell-server not deployed" message).

Closes #1865

Assisted-By: Claude Code