### PR TITLE
fix(ocp): enable apiOAuthSecret in ocp_values.yaml

### DIFF
--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -104,6 +104,9 @@ charts:
         backend:
           defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
           shipwrightDefaultStrategy: "buildah"
+      apiOAuthSecret:
+        enabled: true         # Create kagenti-api-oauth-secret for backend API auth
+        useServiceAccountCA: true
       uiOAuthSecret:
         # for a OCP with self-signed certs for routes it should be true.
         # for a OCP with CA-signed certs for routes it should be false.


### PR DESCRIPTION
## Summary

Adds `apiOAuthSecret.enabled: true` and `apiOAuthSecret.useServiceAccountCA: true`
to `deployments/envs/ocp_values.yaml`. Without this, the e2e
`keycloak_backend_token` fixture skips and backend API auth is unusable
on OCP.

## Cluster tested on

`kagenti-hypershift-custom-ocp1` (HyperShift / OCP 4.20.21).

## Kagenti version under test

v0.6.0-rc.13

## Test plan

- [ ] Fresh deploy on OCP creates `kagenti-api-oauth-secret` in `kagenti-system`
- [ ] `uv run pytest kagenti/tests/e2e/common/test_tool_connect_errors.py`
      no longer skips with "kagenti-api-oauth-secret not found"

Closes #1866

Assisted-By: Claude Code