### PR TITLE
feat(hypershift): emit OCP e2e env exports + ignore generated env files

### DIFF
--- a/.github/scripts/hypershift/setup-hypershift-ci-credentials.sh
+++ b/.github/scripts/hypershift/setup-hypershift-ci-credentials.sh
@@ -892,6 +892,22 @@ export QUOTA_LOAD_BALANCERS=10
 export QUOTA_S3_BUCKETS=5
 export QUOTA_IAM_ROLES=20
 export QUOTA_ROUTE53_ZONES=5
+
+# =============================================================================
+# OCP E2E test environment
+# =============================================================================
+# CLUSTER_SUFFIX is the only value that changes between clusters.
+# Pass it to hypershift-full-test.sh: CLUSTER_SUFFIX=rong ./hypershift-full-test.sh
+# All cluster-specific URLs are derived from it automatically.
+export CLUSTER_SUFFIX="\${CLUSTER_SUFFIX:-\${USER:0:5}}"
+# KUBECONFIG remains pointing to the management cluster (set at the top of this file).
+# Set it to the hosted cluster explicitly after creation:
+#   export KUBECONFIG="\${HOME}/clusters/hcp/${MANAGED_BY_TAG}-\${CLUSTER_SUFFIX}/auth/kubeconfig"
+export MGMT_KUBECONFIG="\${HOME}/.kube/${MANAGED_BY_TAG}-mgmt.kubeconfig"
+export AGENT_URL="https://weather-service-team1.apps.${MANAGED_BY_TAG}-\${CLUSTER_SUFFIX}.${BASE_DOMAIN}"
+export KEYCLOAK_URL="https://keycloak-keycloak.apps.${MANAGED_BY_TAG}-\${CLUSTER_SUFFIX}.${BASE_DOMAIN}"
+export KEYCLOAK_VERIFY_SSL="false"
+export KAGENTI_CONFIG_FILE=deployments/envs/ocp_values.yaml
 ENVFILE
 
 chmod 600 "$ENV_FILE"

--- a/terraform/management-cluster/.gitignore
+++ b/terraform/management-cluster/.gitignore
@@ -23,3 +23,5 @@ output/
 *.pem
 *_rsa
 *_ed25519
+.env.kagenti-*
+.env.hypershift-ci


### PR DESCRIPTION
## Summary

- `setup-hypershift-ci-credentials.sh` now appends to the generated
  `.env.${MANAGED_BY_TAG}` file:
  `CLUSTER_SUFFIX`, `MGMT_KUBECONFIG`, `AGENT_URL`, `KEYCLOAK_URL`,
  `KEYCLOAK_VERIFY_SSL`, `KAGENTI_CONFIG_FILE` — derived from existing vars.
- `terraform/management-cluster/.gitignore` adds `.env.kagenti-*` and
  `.env.hypershift-ci` patterns.

## Cluster tested on

`kagenti-hypershift-custom-ocp1` (HyperShift / OCP 4.20.21).

## Kagenti version under test

v0.6.0-rc.13

## Test plan

- [ ] Fresh `setup-hypershift-ci-credentials.sh` run produces a valid
      `.env.<tag>` that, when `source`d, populates all the new exports
- [ ] `AGENT_URL` matches the actual cluster's weather-service Route
- [ ] `git status` on a clean checkout shows generated `.env.kagenti-*`
      files as ignored

Closes #1868

Assisted-By: Claude Code