### PR TITLE
Docs: local (Kind, gate-only) skill-attestation demo harness

### DIFF
--- a/docs/demos/skill-attestation/.gitignore
+++ b/docs/demos/skill-attestation/.gitignore
@@ -1,0 +1,2 @@
+# runtime working copy, exported from agent-examples by run.sh
+.skills/

--- a/docs/demos/skill-attestation/Dockerfile.agent
+++ b/docs/demos/skill-attestation/Dockerfile.agent
@@ -1,0 +1,21 @@
+# Stand-in "weather agent" for the gate-only skill-attestation demo.
+#
+# We are NOT running the real LLM weather agent here — this demo proves the
+# skill-integrity GATE, not the agent's behaviour. This image just bakes the
+# skill collection at /app (exactly like the real weather-service image does,
+# per the design PDF: "Bakes skill files at /app") and, when it finally runs,
+# prints a line proving the gate released it, then idles so the pod stays Ready.
+#
+# The skill files copied in here are the SAME bytes the gate will hash. Whatever
+# digest skill-hash computes over /app becomes the trusted digest we pin.
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+WORKDIR /app
+# Build context is the exported skill collection (see run.sh prepare_skills):
+# README.md, Dockerfile, src/weather_service/ at the context root.
+COPY . /app/
+
+# Non-root, mirrors the real agent image (USER 1001).
+USER 1001
+
+CMD ["/bin/sh", "-c", "echo '[agent] skill-integrity gate passed — weather agent starting'; exec sleep infinity"]

--- a/docs/demos/skill-attestation/README.md
+++ b/docs/demos/skill-attestation/README.md
@@ -1,0 +1,100 @@
+# Weather-Agent Skill-Integrity Gate — gate-only demo (Kind)
+
+A local, RHTAS-free recreation of the **tamper-evident core** of the
+*SPIFFE Workload Identity–Bound Agent Skill Integrity* demo
+(R. Chang · M. Sabath · M. Iyer · J. Cwiklik et al., 2026-07-01; kagenti epic
+[#2074](https://github.com/kagenti/kagenti/issues/2074)).
+
+## What this shows
+
+An agent's skill files are hashed into a **pinned digest**. At pod startup an
+init container recomputes the digest over the skills it's about to load and
+compares it to the pinned value:
+
+- **match** → gate exits 0, the agent container starts;
+- **mismatch** (a skill was modified, or the pinned digest was flipped) → gate
+  exits 1, the pod is wedged in `Init:Error`, **the agent never starts**.
+
+```
+snapshot-skills ─► skill-integrity-gate ─► agent
+   cp /app→emptyDir    skill-hash verify      starts only if the gate passed
+```
+
+Because it's a rolling update, the previous good pod keeps serving until the new
+one passes — a failed gate never causes an outage.
+
+## What this deliberately OMITS (vs. the full demo)
+
+The full demo adds two more init containers — `skill-attestor-sign` and
+`skill-attestation-verify` — that mint the agent's **SPIFFE JWT-SVID**, use
+`cosign` to **keyless-sign** the verified manifest against **RHTAS/Sigstore**
+(Fulcio + Rekor + TUF), and record an immutable transparency-log entry whose
+signer SAN *is* the workload's SPIFFE ID.
+
+Those steps need RHTAS, which **Kagenti does not install** (it ships SPIRE but no
+Sigstore). The full flow was demoed on an OpenShift cluster (`ykt2`) with the
+RHTAS operator. This gate-only version drops signing + the Rekor audit trail and
+keeps the fail-closed integrity gate, which is the part that blocks a tampered
+skill. See `docs/` references below to extend it to the full pipeline.
+
+## Components
+
+| Piece | Image / source | Role |
+|-------|----------------|------|
+| stand-in agent | built here from `Dockerfile.agent` (ubi9-minimal, skills baked at `/app`) | proves the gate released it; **not** the real LLM agent |
+| integrity gate | `ghcr.io/webchang/skill-hash:0.1.0` (reused as-is) | `skill-hash verify` — recompute & compare the pinned digest |
+| skill collection | `agent-examples/a2a/weather_service` (exported at run time) | `README.md`, `Dockerfile`, `src/weather_service/` |
+
+The skill collection is **not vendored** into this repo — `run.sh` exports it
+fresh from your `agent-examples` clone at run time (`git archive HEAD:a2a/weather_service`,
+exactly as the design PDF does) into a gitignored `.skills/` working copy. This
+avoids duplicating source and keeps it out of repo-wide linting.
+
+The trusted digest is **not hardcoded**: `run.sh up` computes it by running the
+real `skill-hash` image over the exported files, so nothing outside that image
+is in the trust path.
+
+## Prerequisites
+
+Run on the **host** (a sandboxed session cannot reach the podman machine):
+
+- a running container engine — `podman machine start` (or Docker; `ENGINE=docker ./run.sh …`)
+- `kind` and `kubectl` on PATH
+- an `agent-examples` clone; if it isn't at `../../../../agent-examples`, set
+  `AGENT_EXAMPLES=/path/to/agent-examples`
+
+## Run it
+
+```bash
+cd docs/demos/skill-attestation
+
+./run.sh up        # kind cluster + build + compute/pin digest + deploy; waits until Ready
+./run.sh tamper    # modifies a skill file, rolls out; new pod wedges in Init:Error
+./run.sh logs      # shows the gate's "FAILED: digest mismatch"
+./run.sh restore   # reverts the skill; gate passes; agent Running again
+./run.sh down      # tear down
+```
+
+### Expected output
+
+`up` → the gate prints `PASSED: digests match` and the pod goes `Running`; the
+agent logs `[agent] skill-integrity gate passed — weather agent starting`.
+
+`tamper` → the new pod's `skill-integrity-gate` prints
+`FAILED: digest mismatch` and the pod stays in `Init:Error`; the old pod keeps
+running.
+
+## Files
+
+- `run.sh` — host-side driver (up / tamper / restore / logs / down)
+- `Dockerfile.agent` — stand-in agent, bakes the exported skills at `/app`
+- `deployment.yaml.tmpl` — Deployment; `__SKILL_DIGEST__` filled in by `run.sh`
+- `.skills/` — gitignored; the weather skill collection exported at run time
+
+## References
+
+- Design PDF: *SPIFFE Workload Identity–Bound Agent Skill Integrity* (attached to epic #2074)
+- Draft epic: kagenti#2074 (note: the epic proposes a `ClusterStaticEntry` +
+  AuthBridge-egress enforcement mechanism; the implemented demo above enforces at
+  pod-startup via init containers instead — same goal, different enforcement point)
+- Tooling: `github.com/webchang/skill-hash`, `github.com/webchang/skill-attestor`

--- a/docs/demos/skill-attestation/deployment.yaml.tmpl
+++ b/docs/demos/skill-attestation/deployment.yaml.tmpl
@@ -1,0 +1,104 @@
+# Gate-only skill-attestation demo — weather agent on Kind.
+#
+# Faithful subset of the design PDF's init-container pipeline:
+#     snapshot-skills -> skill-integrity-gate -> (agent)
+# The sign / verify (cosign + Rekor) steps are intentionally omitted: they need
+# RHTAS/Sigstore, which Kagenti does not install. This demo proves the
+# tamper-evident core: a modified skill => digest mismatch => pod Init:Error =>
+# agent never starts. Restore => gate passes => agent starts.
+#
+# __SKILL_DIGEST__ is substituted by run.sh with the digest skill-hash computes
+# over the exact baked skill files (developer side == in-pod gate).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-service
+  namespace: team1
+  labels:
+    app: weather-service
+  annotations:
+    # Opt-in: remove these and the gate is a no-op (pipeline skips, exit 0).
+    kagenti.io/skill-root: "/skills"
+    kagenti.io/skill-paths: "README.md,Dockerfile,src/weather_service/"
+    kagenti.io/skill-collection-digest: "__SKILL_DIGEST__"
+    kagenti.io/skill-digest-timestamp: "2026-07-10T00:00:00Z"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: weather-service
+  template:
+    metadata:
+      labels:
+        app: weather-service
+      annotations:
+        kagenti.io/skill-root: "/skills"
+        kagenti.io/skill-paths: "README.md,Dockerfile,src/weather_service/"
+        kagenti.io/skill-collection-digest: "__SKILL_DIGEST__"
+    spec:
+      initContainers:
+
+        # 0 · snapshot-skills — copy the image's baked /app onto a shared
+        # emptyDir so the gate hashes the same tree the agent will read.
+        - name: snapshot-skills
+          image: localhost/weather-service:demo
+          command: ["/bin/sh", "-c", "cp -R /app/. /skills/ && ls -R /skills"]
+          volumeMounts:
+            - name: skills
+              mountPath: /skills
+
+        # 1 · skill-integrity-gate — recompute the digest and compare to the
+        # pinned annotation. match -> exit 0 + write manifest; mismatch -> exit 1
+        # (pod wedged in Init:Error, agent never starts).
+        - name: skill-integrity-gate
+          image: ghcr.io/webchang/skill-hash:0.1.0
+          workingDir: /skills
+          command: ["skill-hash", "verify"]
+          args:
+            - "--root-file"
+            - "/pod-meta/skill-root"
+            - "--paths-from-file"
+            - "/pod-meta/skill-paths"
+            - "--expected-digest-file"
+            - "/pod-meta/skill-collection-digest"
+            - "--output-manifest"
+            - "/skill-signatures/skill-manifest.sha256"
+          volumeMounts:
+            - name: pod-annotations
+              mountPath: /pod-meta
+              readOnly: true
+            - name: skills
+              mountPath: /skills
+              readOnly: true
+            - name: skill-signatures
+              mountPath: /skill-signatures
+
+      containers:
+        - name: agent
+          image: localhost/weather-service:demo
+          volumeMounts:
+            - name: skills
+              mountPath: /skills-verified
+              readOnly: true
+            - name: skill-signatures
+              mountPath: /skill-signatures
+              readOnly: true
+
+      volumes:
+        # Downward API — annotations surfaced as files for the gate.
+        - name: pod-annotations
+          downwardAPI:
+            items:
+              - path: "skill-root"
+                fieldRef:
+                  fieldPath: metadata.annotations['kagenti.io/skill-root']
+              - path: "skill-paths"
+                fieldRef:
+                  fieldPath: metadata.annotations['kagenti.io/skill-paths']
+              - path: "skill-collection-digest"
+                fieldRef:
+                  fieldPath: metadata.annotations['kagenti.io/skill-collection-digest']
+        - name: skills
+          emptyDir: {}
+        - name: skill-signatures
+          emptyDir: {}

--- a/docs/demos/skill-attestation/run.sh
+++ b/docs/demos/skill-attestation/run.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Gate-only skill-attestation demo driver — RUN THIS ON THE HOST (not inside a
+# sandboxed session): it needs a reachable podman machine + Kind.
+#
+# Recreates the tamper-evident core of the weather-agent skill-attestation demo
+# (design: SPIFFE Workload Identity–Bound Agent Skill Integrity, R. Chang et al.),
+# minus the cosign/Rekor signing steps (those need RHTAS/Sigstore).
+#
+# Subcommands:
+#   ./run.sh up        — kind cluster, build+load agent image, compute+pin digest, deploy, wait Ready
+#   ./run.sh tamper     — modify a skill file, roll out, show the gate blocking the pod (Init:Error)
+#   ./run.sh restore    — revert the skill file, roll out, show the gate passing again
+#   ./run.sh logs       — dump the skill-integrity-gate init-container logs
+#   ./run.sh down        — delete the kind cluster
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:$PATH"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER="skill-demo"
+NS="team1"
+IMG="localhost/weather-service:demo"
+GATE_IMG="ghcr.io/webchang/skill-hash:0.1.0"
+ENGINE="${ENGINE:-podman}"        # podman | docker
+
+# The skill collection is NOT vendored into this repo (it would duplicate
+# agent-examples and get pulled into repo-wide linting). Instead we export it
+# fresh from the canonical source at run time — exactly as the design PDF does:
+#   git -C agent-examples archive HEAD:a2a/weather_service | tar -x
+# Point AGENT_EXAMPLES at your local agent-examples clone.
+AGENT_EXAMPLES="${AGENT_EXAMPLES:-$HERE/../../../../agent-examples}"
+SKILLS_DIR="$HERE/.skills"        # gitignored working copy, populated by prepare_skills
+
+# Kind needs to be told to use the podman provider (harmless for docker).
+if [ "$ENGINE" = "podman" ]; then export KIND_EXPERIMENTAL_PROVIDER=podman; fi
+
+# Side-load an image into the Kind node via a saved archive — works for both
+# podman and docker, unlike `kind load docker-image` (docker store only).
+load_into_kind() {
+  local img="$1" tar="/tmp/kind-load-$$.tar"
+  "$ENGINE" save "$img" -o "$tar"
+  kind load image-archive "$tar" --name "$CLUSTER"
+  rm -f "$tar"
+}
+
+log() { printf '\n\033[1;36m== %s\033[0m\n' "$*"; }
+
+require_engine() {
+  if ! "$ENGINE" version >/dev/null 2>&1; then
+    echo "ERROR: '$ENGINE' engine not reachable. Start it (e.g. 'podman machine start') and retry." >&2
+    exit 1
+  fi
+}
+
+prepare_skills() {
+  # Export the weather skill collection from the canonical agent-examples source
+  # into a local, gitignored working copy the demo builds/hashes.
+  [ -d "$AGENT_EXAMPLES/.git" ] || {
+    echo "ERROR: agent-examples clone not found at $AGENT_EXAMPLES (set AGENT_EXAMPLES=)" >&2; exit 1; }
+  rm -rf "$SKILLS_DIR"; mkdir -p "$SKILLS_DIR"
+  git -C "$AGENT_EXAMPLES" archive HEAD:a2a/weather_service | tar -x -C "$SKILLS_DIR"
+  echo "skills exported to $SKILLS_DIR"
+}
+
+compute_digest() {
+  # Compute the trusted digest by running the REAL skill-hash image against the
+  # exported skill files — no reimplementation in the trust path.
+  "$ENGINE" run --rm -v "$SKILLS_DIR:/skills:ro" -w /skills "$GATE_IMG" \
+    compute --root /skills README.md,Dockerfile,src/weather_service/
+}
+
+cmd_up() {
+  require_engine
+  log "Pull gate image ($GATE_IMG)"
+  "$ENGINE" pull "$GATE_IMG"
+
+  log "Export weather skill collection from agent-examples"
+  prepare_skills
+
+  log "Compute trusted skill-collection digest (via real skill-hash image)"
+  DIGEST="$(compute_digest | tr -d '[:space:]')"
+  echo "trusted digest = $DIGEST"
+  [ -n "$DIGEST" ] || { echo "empty digest — aborting"; exit 1; }
+
+  log "Build stand-in agent image ($IMG) with skills baked at /app"
+  "$ENGINE" build -f "$HERE/Dockerfile.agent" -t "$IMG" "$SKILLS_DIR"
+
+  log "Create Kind cluster ($CLUSTER)"
+  kind get clusters 2>/dev/null | grep -qx "$CLUSTER" || kind create cluster --name "$CLUSTER"
+
+  log "Load images into Kind (agent is localhost/ so must be side-loaded)"
+  load_into_kind "$IMG"
+  load_into_kind "$GATE_IMG"
+
+  log "Render deployment with pinned digest and apply"
+  kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+  sed "s|__SKILL_DIGEST__|$DIGEST|g" "$HERE/deployment.yaml.tmpl" | kubectl apply -f -
+
+  log "Wait for the agent to become Ready (gate must pass first)"
+  kubectl -n "$NS" rollout status deploy/weather-service --timeout=120s
+  kubectl -n "$NS" get pods -l app=weather-service
+  echo
+  echo "SUCCESS: gate passed, agent Running. Now try: ./run.sh tamper"
+}
+
+cmd_tamper() {
+  require_engine
+  [ -d "$SKILLS_DIR" ] || { echo "run './run.sh up' first"; exit 1; }
+  log "Tamper: append a line to a skill file (simulates skill modification)"
+  echo "# TAMPERED $(date -u +%FT%TZ)" >> "$SKILLS_DIR/src/weather_service/agent.py"
+  log "Rebuild + reload the agent image (skills baked in change => digest changes)"
+  "$ENGINE" build -f "$HERE/Dockerfile.agent" -t "$IMG" "$SKILLS_DIR"
+  load_into_kind "$IMG"
+  log "Restart the pod — the PINNED digest is unchanged, so the gate must now FAIL"
+  kubectl -n "$NS" rollout restart deploy/weather-service
+  echo "Watching for Init:Error (Ctrl-C once you see it)..."
+  echo "  kubectl -n $NS get pods -l app=weather-service -w"
+  sleep 8
+  kubectl -n "$NS" get pods -l app=weather-service
+  echo
+  echo "Expect: new pod stuck in Init:Error / CrashLoopBackOff on skill-integrity-gate."
+  echo "The OLD pod stays Running (rolling update) — no outage. See ./run.sh logs"
+}
+
+cmd_restore() {
+  require_engine
+  log "Restore: re-export the pristine skill file from agent-examples"
+  prepare_skills
+  "$ENGINE" build -f "$HERE/Dockerfile.agent" -t "$IMG" "$SKILLS_DIR"
+  load_into_kind "$IMG"
+  kubectl -n "$NS" rollout restart deploy/weather-service
+  kubectl -n "$NS" rollout status deploy/weather-service --timeout=120s
+  echo "RESTORED: gate passes again, agent Running."
+}
+
+cmd_logs() {
+  POD="$(kubectl -n "$NS" get pods -l app=weather-service \
+        --sort-by=.metadata.creationTimestamp -o name | tail -1)"
+  log "skill-integrity-gate logs for $POD"
+  kubectl -n "$NS" logs "$POD" -c skill-integrity-gate || true
+}
+
+cmd_down() { kind delete cluster --name "$CLUSTER"; }
+
+case "${1:-}" in
+  up) cmd_up ;;
+  tamper) cmd_tamper ;;
+  restore) cmd_restore ;;
+  logs) cmd_logs ;;
+  down) cmd_down ;;
+  *) echo "usage: $0 {up|tamper|restore|logs|down}"; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Adds a self-contained, local **(Kind, gate-only)** harness that recreates the
tamper-evident core of @webchang's weather-agent skill-attestation demo
(epic #2074), without needing OpenShift or RHTAS/Sigstore.

It lands under `docs/demos/skill-attestation/` and is driven by a single script:

```bash
cd docs/demos/skill-attestation
./run.sh up        # kind cluster; build stand-in agent; compute+pin digest via the real skill-hash image; deploy
./run.sh tamper    # modify a skill file; roll out; new pod wedges in Init:Error
./run.sh logs      # "FAILED: digest mismatch"
./run.sh restore   # revert; gate passes; agent Running
./run.sh down
```

## What it demonstrates

Fail-closed startup gating: a modified skill changes the recomputed digest, it
no longer matches the pinned `kagenti.io/skill-collection-digest`, and the agent
container is **denied startup** (`Init:Error`). Restore → agent starts. The
previous good pod stays `Running` during a failed rollout (no outage).

The driver **self-pins** the trusted digest by running the real
`ghcr.io/webchang/skill-hash:0.1.0` image over the baked skill files — nothing
else is in the trust path. Verified reproducing the design PDF's **exact**
digest (`sha256:66772494…84dd30c`) on the `agent-examples` weather skill
collection. Full verification write-up: #2080.

## Scope / caveats (please read)

This is intentionally a **subset** and is opened as a **draft** for discussion:

- **Gate-only.** The `cosign` sign + Rekor verify steps (`skill-attestor`) are
  omitted — they need RHTAS/Sigstore, which Kagenti doesn't install. The
  signature-failure path is **not** exercised.
- **Enforcement point differs from the DRAFT epic.** This validates the
  *implemented* demo's **pod-startup init-gate**, whereas epic #2074 specifies
  **AuthBridge tool-egress denial** via `ClusterStaticEntry`-bound SVIDs
  (`permissive`/`strict`, deny before token exchange). Not the same mechanism.
- The stand-in agent is a stub (proves the gate released it, not agent behavior).

## Why draft

The epic is still under team review and the enforcement mechanism isn't settled.
Opening this as a draft so we have something concrete to run and critique while
that discussion happens; happy to extend toward the full sign/verify + egress
flow, relocate it, or fold it into the Story-6 (#2080) deliverable once we align.

Refs #2074 #2080
