### PR TITLE
fix(backend): resolve OpenShift Route targetPort by service port name

### DIFF
--- a/rossoctl/backend/app/utils/routes.py
+++ b/rossoctl/backend/app/utils/routes.py
@@ -165,6 +165,34 @@ def create_httproute(
             raise
 
 
+def resolve_openshift_target_port(
+    kube: KubernetesService,
+    service_name: str,
+    namespace: str,
+    service_port: int,
+):
+    """Resolve the value an OpenShift Route should use for spec.port.targetPort.
+
+    OpenShift's router matches a Route's targetPort against the *name* of the
+    backing Service port whenever that port is named; a numeric value equal to
+    the Service's `port` (rather than its container `targetPort`) fails to
+    resolve and the router returns 503. Return the port name when the matching
+    Service port is named, otherwise fall back to the numeric port.
+    """
+    try:
+        service = kube.get_service(namespace=namespace, name=service_name)
+        for sp in service.get("spec", {}).get("ports", []) or []:
+            if sp.get("port") == service_port and sp.get("name"):
+                return sp["name"]
+    except ApiException:
+        logger.warning(
+            "Could not look up Service %s in %s to resolve route targetPort; using numeric port",
+            sanitize_log(service_name),
+            sanitize_log(namespace),
+        )
+    return service_port
+
+
 def create_openshift_route(
     kube: KubernetesService,
     name: str,
@@ -185,6 +213,7 @@ def create_openshift_route(
     name = sanitize_log(name)
     namespace = sanitize_log(namespace)
     service_name = sanitize_log(service_name)
+    target_port = resolve_openshift_target_port(kube, service_name, namespace, service_port)
     route_manifest = {
         "apiVersion": "route.openshift.io/v1",
         "kind": "Route",
@@ -198,7 +227,7 @@ def create_openshift_route(
         "spec": {
             "path": "/",
             "port": {
-                "targetPort": service_port,
+                "targetPort": target_port,
             },
             "to": {
                 "kind": "Service",

--- a/rossoctl/backend/tests/test_routes.py
+++ b/rossoctl/backend/tests/test_routes.py
@@ -210,3 +210,51 @@ class TestSelectRoutePort:
         from app.core.constants import DEFAULT_IN_CLUSTER_PORT
 
         assert select_route_port([]) == DEFAULT_IN_CLUSTER_PORT
+
+
+class TestCreateOpenShiftRoute:
+    """Test cases for create_openshift_route() targetPort resolution."""
+
+    def _service(self, ports):
+        return {"spec": {"ports": ports}}
+
+    def test_named_port_uses_name_as_target_port(self, kubernetes_service):
+        """Route targetPort must reference the Service port by name when named,
+        otherwise the OpenShift router returns 503."""
+        from app.utils.routes import create_openshift_route
+
+        kubernetes_service.get_service = MagicMock(
+            return_value=self._service([{"name": "http", "port": 8080, "target_port": 8000}])
+        )
+        kubernetes_service.create_custom_resource = MagicMock()
+
+        create_openshift_route(kubernetes_service, "my-agent", "team1", "my-agent", 8080)
+
+        body = kubernetes_service.create_custom_resource.call_args.kwargs["body"]
+        assert body["spec"]["port"]["targetPort"] == "http"
+
+    def test_unnamed_port_falls_back_to_number(self, kubernetes_service):
+        from app.utils.routes import create_openshift_route
+
+        kubernetes_service.get_service = MagicMock(
+            return_value=self._service([{"port": 8000, "target_port": 8000}])
+        )
+        kubernetes_service.create_custom_resource = MagicMock()
+
+        create_openshift_route(kubernetes_service, "my-tool", "team1", "my-tool", 8000)
+
+        body = kubernetes_service.create_custom_resource.call_args.kwargs["body"]
+        assert body["spec"]["port"]["targetPort"] == 8000
+
+    def test_service_lookup_failure_falls_back_to_number(self, kubernetes_service):
+        from app.utils.routes import create_openshift_route
+
+        kubernetes_service.get_service = MagicMock(
+            side_effect=ApiException(status=404, reason="Not Found")
+        )
+        kubernetes_service.create_custom_resource = MagicMock()
+
+        create_openshift_route(kubernetes_service, "my-agent", "team1", "my-agent", 8080)
+
+        body = kubernetes_service.create_custom_resource.call_args.kwargs["body"]
+        assert body["spec"]["port"]["targetPort"] == 8080


### PR DESCRIPTION
## Related issue(s)

Fixes #2191

## Summary
- OpenShift's router matches a Route's `spec.port.targetPort` against the **name** of the backing Service port whenever that port is named. The backend currently emits the numeric Service `port`, so the router fails to resolve it and returns **HTTP 503** for agent/tool routes on OpenShift.
- Adds `resolve_openshift_target_port()`, which returns the Service port **name** when the matching port is named, and falls back to the numeric port otherwise. `create_openshift_route()` now uses it.
- The Gateway API `HTTPRoute` path is intentionally unchanged, since `backendRefs.port` requires an integer.

This reproduces on OpenShift clusters (observed on internal `ykt2`/`ykt3` deployments): agent/tool Services expose a named `http` port, and the generated Route's numeric `targetPort` returns 503 until patched to the port name.

## Test plan
- [x] `pytest tests/test_routes.py` — 18 passed (3 new in `TestCreateOpenShiftRoute`)
  - named port → `targetPort` == `"http"`
  - unnamed port → falls back to numeric
  - Service lookup failure (ApiException) → falls back to numeric