### PR TITLE
Docs: Clarify LLM provider selection in weather agent demo

### DIFF
--- a/docs/demos/demo-weather-agent.md
+++ b/docs/demos/demo-weather-agent.md
@@ -26,28 +26,29 @@ Here's a breakdown of the sections:
 
 #### Import New Agent
 
-To deploy the Image Agent:
+To deploy the Weather Agent:
 
 1. Navigate to [Import New Agent](http://rossoctl-ui.localtest.me:8080/Import_New_Agent#import-new-agent) in the Rossoctl UI.
 2. Under **Select Agent**, choose `Weather Service Agent`
 3. Expand **Environment Variables**
-  - Choose `Import from File/URL
-  - Edit the URL to read `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.ollama`
-    - If using OpenAI LLMs, skip this step
+  - Choose `Import from File/URL`
+  - Set the URL for your LLM provider:
+    - **Local model (Ollama):** `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.ollama`
+    - **OpenAI:** `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.openai`
   - Click `Fetch and Parse`
   - Click `Import`
 4. Click **Build & Deploy Agent** to deploy.
 
-**Note:** The `ollama` environmental variable set specifies `gpt-oss:latest` as the default model. To download the model, run `ollama pull gpt-oss:latest`. Please ensure an Ollama server is running in a separate terminal via `ollama serve`.
+**Note:** The `.env.ollama` variable set specifies `gpt-oss:latest` as the default model. To download the model, run `ollama pull gpt-oss:latest`, and ensure an Ollama server is running in a separate terminal via `ollama serve`. The `.env.openai` set uses your OpenAI API key from the `openaiApiKey` value you configured in `deployments/envs/.secret_values.yaml` during [installation](../overview/5-quickstart.md); no local model is needed.
 
 ---
 
 #### Import New Tool
 
-To deploy the Image Tool using Shipwright:
+To deploy the Weather Tool using Shipwright:
 
 1. Navigate to [Import New Tool](http://rossoctl-ui.localtest.me:8080/Import_New_Tool#import-new-tool) in the UI.
-2. Under **Select Tool*, choose `Weather Tool`
+2. Under **Select Tool**, choose `Weather Tool`
 3. Click **Build & Deploy Tool** to deploy.
 
 You will be redirected to a **Build Progress** page where you can monitor the Shipwright build. Once the build succeeds, the Deployment and Service for the tool will be created automatically.


### PR DESCRIPTION
## Problem

In the **Import New Agent** step of the weather agent demo, the environment-variable instructions gave a single Ollama `.env` URL followed by:

> If using OpenAI LLMs, skip this step

This is ambiguous. It is unclear whether "skip this step" means skip the entire Import New Agent step or just the URL import, and OpenAI users are never told what to use instead. (Raised by a user following the published demo.)

## Fix

- Give an explicit `.env` URL **per provider** so there is nothing to "skip":
  - Local model (Ollama): `.env.ollama`
  - OpenAI: `.env.openai`
- Clarify the note: the OpenAI set uses the `openaiApiKey` value configured in `deployments/envs/.secret_values.yaml` at install time, and no local model is needed. Links to the quickstart install page.
- Fix incidental typos in the same section: unclosed backtick on `Import from File/URL`, "Image Agent"/"Image Tool" -> "Weather", and the malformed `**Select Tool*`.

## Notes

The `.env.openai` file already exists in [rossoctl/examples](https://github.com/rossoctl/examples/tree/main/a2a/weather_service), so the OpenAI URL resolves. Docs-only change; no code affected.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>