### PR TITLE
fix: Explain when Context Service is disabled

### DIFF
--- a/rossoctl/backend/app/main.py
+++ b/rossoctl/backend/app/main.py
@@ -54,12 +54,13 @@ class NoCacheMiddleware:
 from app.core.config import settings  # pylint: disable=wrong-import-position
 from app.routers import (  # pylint: disable=wrong-import-position
     agents,
-    tools,
-    namespaces,
-    config,
     auth,
     chat,
+    config,
+    contexts,
+    namespaces,
     shipwright,
+    tools,
 )
 
 # Conditionally import feature-flagged modules.
@@ -115,17 +116,6 @@ if settings.rossoctl_feature_flag_skills:
     except ImportError:
         logging.getLogger(__name__).warning(
             "SKILLS flag enabled but skills modules not installed — skipping"
-        )
-
-_contexts_module_loaded = False
-if settings.context_service_url.strip():
-    try:
-        from app.routers import contexts  # noqa: E402
-
-        _contexts_module_loaded = True
-    except ImportError:
-        logging.getLogger(__name__).warning(
-            "CONTEXT_SERVICE flag enabled but context module not installed — skipping"
         )
 
 _acp_modules_loaded = False
@@ -275,6 +265,8 @@ app.include_router(tools.router, prefix="/api/v1")
 app.include_router(config.router, prefix="/api/v1")
 app.include_router(chat.router, prefix="/api/v1")
 app.include_router(shipwright.router, prefix="/api/v1")
+app.include_router(contexts.router, prefix="/api/v1")
+app.include_router(contexts.storage_classes_router, prefix="/api/v1")
 
 # Feature-flagged routers (variables are assigned inside try/except blocks above;
 # pylint cannot track that _*_modules_loaded guards their usage).
@@ -301,11 +293,6 @@ if _integrations_modules_loaded:
 if _skills_modules_loaded:
     app.include_router(skills.router, prefix="/api/v1")
     logger.info("Feature flag SKILLS enabled — skills routes registered")
-
-if _contexts_module_loaded:
-    app.include_router(contexts.router, prefix="/api/v1")
-    app.include_router(contexts.storage_classes_router, prefix="/api/v1")
-    logger.info("Feature flag CONTEXT_SERVICE enabled — context routes registered")
 
 if _acp_modules_loaded:
     app.include_router(acp.router, prefix="/api/v1")

--- a/rossoctl/backend/app/routers/agents_manifests.py
+++ b/rossoctl/backend/app/routers/agents_manifests.py
@@ -940,10 +940,12 @@ async def _resolve_context_mounts(
             status_code=400,
             detail="context attachments require a statefulset or sandbox workload",
         )
-    if not settings.context_service_url.strip():
-        raise HTTPException(status_code=400, detail="Context Service integration is disabled")
+    from app.routers.contexts import (  # pylint: disable=import-outside-toplevel
+        require_context_service,
+        resolve_context,
+    )
 
-    from app.routers.contexts import resolve_context  # pylint: disable=import-outside-toplevel
+    require_context_service()
 
     volumes: List[Dict[str, Any]] = []
     mounts: List[Dict[str, Any]] = []

--- a/rossoctl/backend/app/routers/contexts.py
+++ b/rossoctl/backend/app/routers/contexts.py
@@ -15,6 +15,14 @@ router = APIRouter(prefix="/contexts", tags=["contexts"])
 storage_classes_router = APIRouter(prefix="/context-storage-classes", tags=["contexts"])
 
 _KUBERNETES_NAME = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
+CONTEXT_SERVICE_DOCS_URL = (
+    "https://github.com/rossoctl/rossoctl/blob/main/docs/concepts/context-service.md"
+)
+CONTEXT_SERVICE_DISABLED_DETAIL = (
+    "Context Service is not enabled on this Rosso installation. "
+    "Ask a cluster administrator to configure it; setup instructions: "
+    f"{CONTEXT_SERVICE_DOCS_URL}"
+)
 
 
 class ContextStorage(BaseModel):
@@ -45,9 +53,14 @@ def _path_segment(value: str, field: str, max_length: int = 63) -> str:
     return quote(value, safe="")
 
 
-async def _request(method: str, path: str, body: dict | None = None) -> httpx.Response:
+def require_context_service() -> None:
+    """Fail with an actionable response when the optional integration is disabled."""
     if not settings.context_service_url.strip():
-        raise HTTPException(status_code=400, detail="Context Service integration is disabled")
+        raise HTTPException(status_code=503, detail=CONTEXT_SERVICE_DISABLED_DETAIL)
+
+
+async def _request(method: str, path: str, body: dict | None = None) -> httpx.Response:
+    require_context_service()
     try:
         async with httpx.AsyncClient(timeout=settings.context_service_timeout) as client:
             response = await client.request(method, _url(path), json=body)

--- a/rossoctl/backend/app/routers/contexts.py
+++ b/rossoctl/backend/app/routers/contexts.py
@@ -56,7 +56,7 @@ def _path_segment(value: str, field: str, max_length: int = 63) -> str:
 def require_context_service() -> None:
     """Fail with an actionable response when the optional integration is disabled."""
     if not settings.context_service_url.strip():
-        raise HTTPException(status_code=503, detail=CONTEXT_SERVICE_DISABLED_DETAIL)
+        raise HTTPException(status_code=501, detail=CONTEXT_SERVICE_DISABLED_DETAIL)
 
 
 async def _request(method: str, path: str, body: dict | None = None) -> httpx.Response:

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -99,17 +99,17 @@ async def test_context_proxy_requires_service_url() -> None:
         await contexts.list_contexts("team1")
 
     client.assert_not_called()
-    assert exc_info.value.status_code == 503
+    assert exc_info.value.status_code == 501
     assert exc_info.value.detail == contexts.CONTEXT_SERVICE_DISABLED_DETAIL
     assert contexts.CONTEXT_SERVICE_DOCS_URL in exc_info.value.detail
 
 
 def test_context_route_returns_actionable_error_when_service_is_disabled() -> None:
-    """A current server should return a useful 503, not look like an old 404 server."""
+    """A current server should return a useful 501, not look like an old 404 server."""
     with patch("app.routers.contexts.settings.context_service_url", ""):
         response = TestClient(app).get("/api/v1/contexts/team1")
 
-    assert response.status_code == 503
+    assert response.status_code == 501
     assert response.json()["detail"] == contexts.CONTEXT_SERVICE_DISABLED_DETAIL
     assert contexts.CONTEXT_SERVICE_DOCS_URL in response.json()["detail"]
 
@@ -142,7 +142,7 @@ async def test_context_attachments_require_service_url() -> None:
         with pytest.raises(HTTPException) as exc_info:
             await _resolve_context_mounts("team1", [ContextAttachment(name="research")], "sandbox")
 
-    assert exc_info.value.status_code == 503
+    assert exc_info.value.status_code == 501
     assert exc_info.value.detail == contexts.CONTEXT_SERVICE_DISABLED_DETAIL
 
 

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 from kubernetes.client import ApiException
 
+from app.main import app
 from app.routers import contexts
 from app.routers.agents import (
     ContextAttachment,
@@ -92,11 +94,24 @@ async def test_context_proxy_requires_service_url() -> None:
     with (
         patch("app.routers.contexts.settings.context_service_url", ""),
         patch("app.routers.contexts.httpx.AsyncClient") as client,
-        pytest.raises(HTTPException, match="integration is disabled"),
+        pytest.raises(HTTPException) as exc_info,
     ):
         await contexts.list_contexts("team1")
 
     client.assert_not_called()
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == contexts.CONTEXT_SERVICE_DISABLED_DETAIL
+    assert contexts.CONTEXT_SERVICE_DOCS_URL in exc_info.value.detail
+
+
+def test_context_route_returns_actionable_error_when_service_is_disabled() -> None:
+    """A current server should return a useful 503, not look like an old 404 server."""
+    with patch("app.routers.contexts.settings.context_service_url", ""):
+        response = TestClient(app).get("/api/v1/contexts/team1")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == contexts.CONTEXT_SERVICE_DISABLED_DETAIL
+    assert contexts.CONTEXT_SERVICE_DOCS_URL in response.json()["detail"]
 
 
 @pytest.mark.asyncio
@@ -124,8 +139,11 @@ async def test_context_paths_reject_invalid_kubernetes_names(
 @pytest.mark.asyncio
 async def test_context_attachments_require_service_url() -> None:
     with patch("app.routers.agents.settings.context_service_url", ""):
-        with pytest.raises(HTTPException, match="disabled"):
+        with pytest.raises(HTTPException) as exc_info:
             await _resolve_context_mounts("team1", [ContextAttachment(name="research")], "sandbox")
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == contexts.CONTEXT_SERVICE_DISABLED_DETAIL
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Context Service is optional, but its routes were previously registered only when CONTEXT_SERVICE_URL was configured. On installations without it, context commands therefore returned an ambiguous 404 that looked like an outdated Rosso server.

Always register the context routes and return an actionable 503 when the integration is disabled. The response explains that a cluster administrator must configure Context Service and links to the existing setup documentation. Agent imports with context attachments use the same response.

## Acceptance tier

- [x] Tier 0 — Maintenance (bugfix / docs / dependency bump / no-behavior refactor)
- [ ] Tier 1 — Standard feature (net-new user-facing behavior)
- [ ] Tier 2 — Large / contested feature (new subsystem, cross-repo, high-risk, or disputed value)

## Checklist

### Pillar 1 — Code quality

- [x] Focused Ruff checks pass
- [x] Tests added/updated and passing
- [x] Follows repo conventions
- [x] DCO sign-off on all commits

### Pillar 2 — Documentation

- [x] Existing setup documentation is linked from the error response

## Testing

- `uv run pytest tests/test_contexts.py -q` — 24 passed
- `uv run ruff check app/main.py app/routers/contexts.py app/routers/agents_manifests.py tests/test_contexts.py`
- HTTP-level coverage verifies `GET /api/v1/contexts/team1` returns 503, actionable guidance, and the setup URL when Context Service is unset.

Assisted-By: Codex