### PR TITLE
fix(chart): only manage openai-secret when secrets.openaiApiKey is set

### DIFF
--- a/charts/rossoctl/templates/NOTES.txt
+++ b/charts/rossoctl/templates/NOTES.txt
@@ -18,6 +18,24 @@ Show all service URLs and credentials:
 ```
   .github/scripts/local-setup/show-services.sh
 ```
+{{- if not .Values.secrets.openaiApiKey }}
+
+============================================================================
+  WARNING: secrets.openaiApiKey is NOT set
+============================================================================
+The chart did NOT create/manage the `openai-secret` Secret in the agent
+namespace(s). Agents and tools that call an LLM read their API key from
+`openai-secret` (key: `apikey`) at pod startup and will fail to run until it
+exists. Provision it out-of-band BEFORE deploying workloads, e.g.:
+
+  kubectl -n <agent-namespace> create secret generic openai-secret \
+    --from-literal=apikey="$YOUR_LLM_API_KEY"
+
+Leaving secrets.openaiApiKey empty is the supported way to keep the key out
+of Helm values so that a later `helm upgrade` cannot overwrite an
+operator-managed secret with an empty value.
+============================================================================
+{{- end }}
 
 
 

--- a/charts/rossoctl/templates/agent-namespace-resources.yaml
+++ b/charts/rossoctl/templates/agent-namespace-resources.yaml
@@ -52,6 +52,11 @@ data:
 ---
 {{ end }}
 # 4. OpenAI API Key Secret
+#    Only managed by the chart when secrets.openaiApiKey is set. When left empty the Secret is
+#    expected to be provisioned out-of-band (e.g. `kubectl create secret generic openai-secret
+#    --from-literal=apikey=...`) so that `helm upgrade` does not overwrite an operator-managed
+#    key with an empty value. Mirrors the conditional GitHub secrets above.
+{{- if $.Values.secrets.openaiApiKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -63,6 +68,7 @@ type: Opaque
 stringData:
   apikey: {{ $.Values.secrets.openaiApiKey | quote }}
 ---
+{{- end }}
 # 5. Slack Bot Tokens Secret
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Fixes #2485.

## Problem

The agent-namespace `openai-secret` Secret in `charts/rossoctl/templates/agent-namespace-resources.yaml` was rendered unconditionally:

```yaml
stringData:
  apikey: {{ $.Values.secrets.openaiApiKey | quote }}
```

With `secrets.openaiApiKey` empty (the intended state when the LLM key is provisioned out-of-band), **every `helm upgrade` re-writes an empty `apikey`**, silently zeroing an operator-managed key. Workloads read it via `secretKeyRef` at pod start, so LLM calls fail until the Secret is restored and pods are restarted.

## Change

- **Guard the Secret** with `{{- if $.Values.secrets.openaiApiKey }}`, mirroring the conditional GitHub secrets already in the same template. Empty value ⇒ the chart no longer creates or overwrites `openai-secret`, so an out-of-band Secret survives upgrades. Non-empty value ⇒ unchanged behavior (backward compatible).
- **`NOTES.txt` WARNING** when `secrets.openaiApiKey` is unset, telling operators to provision `openai-secret` out-of-band before deploying workloads.

## Validation

`helm template` (chart 0.7.0):
- key empty → `openai-secret` **not** rendered (0 objects)
- key set → rendered exactly once

Enacted on a live cluster (chart 0.7.0, `--reuse-values`):
- `helm diff upgrade` showed the **only** change was `openai-secret` dropped from the release manifest — no other churn.
- After annotating the live Secret `helm.sh/resource-policy=keep` and disowning Helm ownership metadata, the `helm upgrade` **preserved** the real key (previously this exact operation wiped it).
- NOTES `WARNING` rendered on the live upgrade.
- Post-upgrade: platform pods healthy; a gsm8k benchmark run succeeded (pass_rate 1.0, 0 errored), confirming the out-of-band Secret is consumed correctly.

## Adoption note (existing releases)

To adopt without losing a live key, **before** upgrading annotate the Secret `helm.sh/resource-policy=keep` (and strip its Helm ownership label/annotations) so the upgrade that removes it from the release manifest does not prune it.

Assisted-By: Claude Code

