### PR TITLE
feat(backend): accept AuthBridge plugin preset and pass onto AgentRuntime.spec

### DIFF
--- a/rossoctl/backend/app/models/shipwright.py
+++ b/rossoctl/backend/app/models/shipwright.py
@@ -139,6 +139,12 @@ class ResourceConfigFromBuild(BaseModel):
     # that read it back via model_dump() during Shipwright finalize.
     k8sResourceLimits: Optional[Dict[str, str]] = None
     k8sResourceRequests: Optional[Dict[str, str]] = None
+    # AuthBridge layer-3 plugin composition stashed at form-submit time. Declared
+    # here for the same reason as k8sResourceLimits above — undeclared annotation
+    # keys are dropped by this model's default extra="ignore".
+    pluginPreset: Optional[str] = None
+    plugins: Optional[List[str]] = None
+    onError: Optional[str] = None
 
 
 class ShipwrightBuildInfoResponse(BaseModel):

--- a/rossoctl/backend/app/routers/agents_create.py
+++ b/rossoctl/backend/app/routers/agents_create.py
@@ -290,6 +290,9 @@ async def create_agent(
                     auth_bridge_mode=request.authBridgeMode,
                     mtls_mode=request.mtlsMode,
                     tls_bridge_enabled=request.tlsBridgeEnabled,
+                    plugin_preset=request.pluginPreset,
+                    plugins=request.plugins,
+                    on_error=request.onError,
                 )
                 created.append(("AgentRuntime", request.name))
 

--- a/rossoctl/backend/app/routers/agents_finalize.py
+++ b/rossoctl/backend/app/routers/agents_finalize.py
@@ -374,6 +374,22 @@ async def finalize_shipwright_build(
             else bool(stored_config.get("tlsBridgeEnabled"))
         )
 
+        # AuthBridge layer-3 plugin composition (pluginPreset / plugins /
+        # onError). Same store-then-read-back flow as mtlsMode so a
+        # build-from-source agent inherits the plugin pipeline the user picked
+        # at form-submit time (stashed on the BuildRun annotation).
+        final_plugin_preset = (
+            request.pluginPreset
+            if request.pluginPreset is not None
+            else stored_config.get("pluginPreset")
+        )
+        final_plugins = (
+            request.plugins if request.plugins is not None else stored_config.get("plugins")
+        )
+        final_on_error = (
+            request.onError if request.onError is not None else stored_config.get("onError")
+        )
+
         # Persistent storage
         final_persistent_storage = request.persistentStorage
         if final_persistent_storage is None and stored_config.get("persistentStorage"):
@@ -430,6 +446,9 @@ async def finalize_shipwright_build(
             authBridgeMode=final_auth_bridge_mode,
             mtlsMode=final_mtls_mode,
             tlsBridgeEnabled=final_tls_bridge_enabled,
+            pluginPreset=final_plugin_preset,
+            plugins=final_plugins,
+            onError=final_on_error,
             outboundRoutes=final_outbound_routes,
             outboundPortsExclude=final_outbound_ports_exclude,
             inboundPortsExclude=final_inbound_ports_exclude,
@@ -615,6 +634,9 @@ async def finalize_shipwright_build(
                 auth_bridge_mode=final_auth_bridge_mode,
                 mtls_mode=final_mtls_mode,
                 tls_bridge_enabled=final_tls_bridge_enabled,
+                plugin_preset=final_plugin_preset,
+                plugins=final_plugins,
+                on_error=final_on_error,
             )
 
         message = f"Agent '{name}' deployed as {final_workload_type} with image '{output_image}'."

--- a/rossoctl/backend/app/routers/agents_manifests.py
+++ b/rossoctl/backend/app/routers/agents_manifests.py
@@ -238,6 +238,9 @@ def _build_agentruntime_manifest(
     auth_bridge_mode: Optional[str] = None,
     mtls_mode: Optional[str] = None,
     tls_bridge_enabled: bool = False,
+    plugin_preset: Optional[str] = None,
+    plugins: Optional[List[str]] = None,
+    on_error: Optional[str] = None,
 ) -> dict:
     """Build an AgentRuntime CR manifest for the given workload."""
     kind_map = {
@@ -267,6 +270,16 @@ def _build_agentruntime_manifest(
     # CRD field off envoy-sidecar agents so the validating webhook doesn't reject).
     if tls_bridge_enabled:
         spec["tlsBridgeMode"] = "enabled"
+    # AuthBridge layer-3 plugin composition. Only set when a preset is chosen;
+    # unset → operator keeps its default 2-plugin pipeline (jwt-validation +
+    # token-exchange), so existing agents are unaffected. plugins/onError are
+    # only meaningful alongside a preset (they refine the selected pipeline).
+    if plugin_preset:
+        spec["pluginPreset"] = plugin_preset
+        if plugins:
+            spec["plugins"] = plugins
+        if on_error:
+            spec["onError"] = on_error
     return {
         "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
         "kind": "AgentRuntime",
@@ -291,6 +304,9 @@ def _ensure_agentruntime(
     auth_bridge_mode: Optional[str] = None,
     mtls_mode: Optional[str] = None,
     tls_bridge_enabled: bool = False,
+    plugin_preset: Optional[str] = None,
+    plugins: Optional[List[str]] = None,
+    on_error: Optional[str] = None,
 ) -> None:
     """Create an AgentRuntime CR for the workload. Skip if it already exists."""
     manifest = _build_agentruntime_manifest(
@@ -301,6 +317,9 @@ def _ensure_agentruntime(
         auth_bridge_mode,
         mtls_mode,
         tls_bridge_enabled,
+        plugin_preset,
+        plugins,
+        on_error,
     )
     try:
         kube.create_custom_resource(

--- a/rossoctl/backend/app/routers/agents_models.py
+++ b/rossoctl/backend/app/routers/agents_models.py
@@ -204,6 +204,22 @@ class CreateAgentRequest(BaseModel):
     # Outbound routing rules (authproxy-routes ConfigMap)
     outboundRoutes: Optional[List["OutboundRoute"]] = None
 
+    # AuthBridge layer-3 plugin composition. Maps to
+    # AgentRuntime.Spec.PluginPreset / Plugins / OnError, which the operator
+    # webhook renders into the per-agent authbridge-config-<agent> ConfigMap's
+    # pipeline: block (seeded from the namespace authbridge-runtime-config base
+    # so jwt/token-exchange config survives). When pluginPreset is None the
+    # operator keeps its default 2-plugin pipeline (jwt-validation +
+    # token-exchange), so existing agents are unaffected.
+    #   - pluginPreset: named composition (auth-only / ibac-only / full)
+    #   - plugins: per-plugin policy overrides, tokens "name:policy"
+    #     (policy ∈ enforce|observe|off), e.g. "ibac:observe"
+    #   - onError: chain-default policy applied to selected plugins that have
+    #     no explicit per-plugin override
+    pluginPreset: Optional[Literal["auth-only", "ibac-only", "full"]] = None
+    plugins: Optional[List[str]] = None
+    onError: Optional[Literal["enforce", "observe", "off"]] = None
+
     # Persistent storage (for Sandbox and StatefulSet workloads)
     persistentStorage: Optional[PersistentStorageConfig] = None
 
@@ -399,6 +415,13 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
+    # Mirror CreateAgentRequest AuthBridge layer-3 plugin composition. None →
+    # inherit the value stashed on the BuildRun's rossoctl.io/agent-config
+    # annotation at form-submit time, so a build-from-source agent gets the
+    # same plugin pipeline as a direct-image one.
+    pluginPreset: Optional[Literal["auth-only", "ibac-only", "full"]] = None
+    plugins: Optional[List[str]] = None
+    onError: Optional[Literal["enforce", "observe", "off"]] = None
     persistentStorage: Optional[PersistentStorageConfig] = None
     mcpToolName: Optional[str] = None
     llmPreset: Optional[str] = None

--- a/rossoctl/backend/app/routers/agents_skills.py
+++ b/rossoctl/backend/app/routers/agents_skills.py
@@ -195,6 +195,14 @@ def _build_agent_shipwright_build_manifest(
         resource_config["mtlsMode"] = request.mtlsMode
     if request.tlsBridgeEnabled:
         resource_config["tlsBridgeEnabled"] = True
+    # AuthBridge layer-3 plugin composition, stashed for the finalize step so a
+    # build-from-source agent's pipeline survives the async build round-trip.
+    if request.pluginPreset:
+        resource_config["pluginPreset"] = request.pluginPreset
+    if request.plugins:
+        resource_config["plugins"] = request.plugins
+    if request.onError:
+        resource_config["onError"] = request.onError
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
     if request.k8sResourceLimits is not None:


### PR DESCRIPTION
Closes #2487.

## What

Adds three optional fields to the agent-create request and threads them onto the `AgentRuntime.spec`
so the operator can render the full AuthBridge layer-3 pipeline (companion: rossoctl/operator#523):

- `pluginPreset`: `auth-only` | `ibac-only` | `full`
- `plugins`: list of `name:policy` override tokens (e.g. `"ibac:observe"`)
- `onError`: `enforce` | `observe` | `off` (chain-default policy)

Mirrors the existing `authBridgeMode` passthrough. The fields flow through both the image path
(`agents_create.py`) and the build-from-source Shipwright round-trip (`agents_skills.py` →
`agents_finalize.py`), and are emitted into the manifest by `_build_agentruntime_manifest`.
All three default to `None`; existing callers are unaffected.

## Changed

- `agents_models.py` — new request fields (+ the duplicated finalize request).
- `agents_manifests.py` — set `spec.pluginPreset` / `plugins` / `onError` when present.
- `agents_create.py`, `agents_finalize.py`, `agents_skills.py`, `models/shipwright.py` — thread the
  values through the create + build-from-source paths.

## Test plan

Validated end-to-end cross-cluster (Benchmarking Service → this backend → operator webhook →
per-agent `authbridge-config-<agent>` ConfigMap → AuthBridge sidecar). Preset deploys that
previously returned 422 now provision the intended pipeline; a small IBAC-comparison benchmark
showed the expected `enforce` (denies non-essential outbound calls) vs `observe` (passes) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
