### PR TITLE
docs: fix Weather Agent Ollama model name (C3)

### DIFF
--- a/docs/demos/cli-demo-weather-agent.md
+++ b/docs/demos/cli-demo-weather-agent.md
@@ -63,7 +63,7 @@ You will receive a response:
 Agent 'weather-service' deployed as deployment successfully.
 ```
 
-**Note:** The `.env.ollama` variable set specifies `gpt-oss:latest` as the default model. To download the model, run `ollama pull gpt-oss:latest`, and ensure an Ollama server is running in a separate terminal via `ollama serve`. The `.env.openai` set uses your OpenAI API key from the `openaiApiKey` value you configured in `deployments/envs/.secret_values.yaml` during [installation](../overview/5-quickstart.md); no local model is needed.
+**Note:** The `.env.ollama` variable set specifies `llama3.2:3b-instruct-fp16` as the default model. To download the model, run `ollama pull llama3.2:3b-instruct-fp16`, and ensure an Ollama server is running in a separate terminal via `ollama serve`. The `.env.openai` set uses your OpenAI API key from the `openaiApiKey` value you configured in `deployments/envs/.secret_values.yaml` during [installation](../overview/5-quickstart.md); no local model is needed.
 
 ---
 

--- a/docs/demos/demo-weather-agent.md
+++ b/docs/demos/demo-weather-agent.md
@@ -40,7 +40,7 @@ To deploy the Weather Agent:
   - Click `Import`
 4. Click **Build & Deploy Agent** to deploy.
 
-**Note:** The `.env.ollama` variable set specifies `gpt-oss:latest` as the default model. To download the model, run `ollama pull gpt-oss:latest`, and ensure an Ollama server is running in a separate terminal via `ollama serve`. The `.env.openai` set uses your OpenAI API key from the `openaiApiKey` value you configured in `deployments/envs/.secret_values.yaml` during [installation](../overview/5-quickstart.md); no local model is needed.
+**Note:** The `.env.ollama` variable set specifies `llama3.2:3b-instruct-fp16` as the default model. To download the model, run `ollama pull llama3.2:3b-instruct-fp16`, and ensure an Ollama server is running in a separate terminal via `ollama serve`. The `.env.openai` set uses your OpenAI API key from the `openaiApiKey` value you configured in `deployments/envs/.secret_values.yaml` during [installation](../overview/5-quickstart.md); no local model is needed.
 
 ---
 


### PR DESCRIPTION
## Summary

Both Weather Agent demo docs told readers the default Ollama model is `gpt-oss:latest`, but the agent's env file (`rossoctl/examples` → `a2a/weather_service/.env.ollama`) sets:

```
LLM_MODEL=llama3.2:3b-instruct-fp16
```

So a reader following the note runs `ollama pull gpt-oss:latest` — the wrong model for what the demo actually deploys. Corrected the note in both:

- `docs/demos/demo-weather-agent.md`
- `docs/demos/cli-demo-weather-agent.md`

## Verification

- Source of truth confirmed: `.env.ollama` = `llama3.2:3b-instruct-fp16`.
- Checked the rest of both docs while here — the linked targets (`getting-started/install.md`, `overview/5-quickstart.md`, `users-guides/troubleshooting.md`) all resolve, and no other stale references were found in these files.
- `docs/getting-started/llms/local-models.md` uses `qwen2.5:3b` as a generic example and lists `gpt-oss:latest` in a "Tested Models" table for *other* agents — neither is what the weather demo's env sets, so the demo docs are matched to the env file rather than to that table.

This is correction **C3** from the weather-agent demo verification effort; it was intended for #2479 but merged without it. Pairs with the merged demo-fix PRs rossoctl/cortex#818 and rossoctl/cortex#819.

Fixes #2515

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
