### PR TITLE
ci(docs): guard weather demo against Ollama model-name drift

### DIFF
--- a/.github/scripts/docs/check-ollama-model-drift.sh
+++ b/.github/scripts/docs/check-ollama-model-drift.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# check-ollama-model-drift.sh
+#
+# Guards against the demo docs drifting out of sync with the Ollama model name
+# that is the source of truth in the rossoctl/examples repo.
+#
+# Currently scoped to the weather demo ONLY, because it is the sole agent that
+# actually publishes an `.env.ollama` in rossoctl/examples. The image, generic,
+# file-organizer, and slack demos reference an `.env.ollama` that does not yet
+# exist in the examples repo -- see rossoctl/rossoctl#2527. Extend the CHECKS
+# array once those files are published.
+#
+# Exit codes: 0 = in sync, 1 = drift detected, 2 = could not fetch source.
+
+set -euo pipefail
+
+# doc_path <TAB> raw_env_url
+CHECKS=(
+  "docs/demos/demo-weather-agent.md	https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.ollama"
+)
+
+fetch_with_retry() {
+  # $1 = url. Retries to absorb transient network flake.
+  local url="$1" attempt
+  for attempt in 1 2 3; do
+    if curl -fsSL --max-time 20 "$url"; then
+      return 0
+    fi
+    echo "  fetch attempt ${attempt} failed for ${url}" >&2
+    sleep $((attempt * 2))
+  done
+  return 1
+}
+
+status=0
+for entry in "${CHECKS[@]}"; do
+  doc="${entry%%$'\t'*}"
+  url="${entry##*$'\t'}"
+
+  echo "Checking ${doc} against ${url}"
+
+  if [[ ! -f "${doc}" ]]; then
+    echo "::error file=${doc}::doc not found" >&2
+    status=1
+    continue
+  fi
+
+  env_contents="$(fetch_with_retry "${url}")" || {
+    echo "::error::could not fetch ${url} after retries (network flake?)" >&2
+    status=2
+    continue
+  }
+
+  # Extract LLM_MODEL=... (tolerate optional quotes/whitespace).
+  model="$(printf '%s\n' "${env_contents}" \
+    | grep -iE '^[[:space:]]*LLM_MODEL[[:space:]]*=' \
+    | head -1 \
+    | sed -E 's/^[^=]*=[[:space:]]*//; s/^["'\'']//; s/["'\'']$//; s/[[:space:]]*$//')"
+
+  if [[ -z "${model}" ]]; then
+    echo "::error::no LLM_MODEL found in ${url}" >&2
+    status=2
+    continue
+  fi
+
+  if grep -qF -- "${model}" "${doc}"; then
+    echo "  OK: '${model}' present in ${doc}"
+  else
+    echo "::error file=${doc}::model '${model}' from ${url} not found in ${doc} (docs drifted?)" >&2
+    status=1
+  fi
+done
+
+if [[ "${status}" -eq 0 ]]; then
+  echo "All Ollama model references are in sync."
+fi
+exit "${status}"

--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -11,6 +11,7 @@ on:
       - "**.md"
       - "docs/**"
       - ".github/workflows/docs-ci.yaml"
+      - ".github/scripts/docs/**"
       - ".markdownlint-cli2.yaml"
       - ".lychee.toml"
 
@@ -84,3 +85,33 @@ jobs:
             --config .lychee.toml
             "**/*.md"
           fail: false
+
+  ollama-model-drift:
+    name: Ollama Model Drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # Guards the demo docs against drifting out of sync with the Ollama model
+      # name that is the source of truth in rossoctl/examples. Currently scoped
+      # to the weather demo only — it is the sole agent that publishes an
+      # `.env.ollama` in the examples repo. The other demos reference an
+      # `.env.ollama` that does not yet exist there (rossoctl/rossoctl#2527);
+      # extend the CHECKS array in the script once those files are published.
+      #
+      # Real drift (script exit 1) fails the job. A source-fetch failure
+      # (exit 2, e.g. network flake reaching raw.githubusercontent.com) is
+      # treated as advisory: it warns but does not fail, keeping this repo's CI
+      # from going red on another repo's/CDN's transient unavailability.
+      - name: Check Ollama model references
+        run: |
+          set +e
+          bash .github/scripts/docs/check-ollama-model-drift.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "::warning::could not fetch source .env.ollama (network flake?); skipping drift gate"
+            exit 0
+          fi
+          exit "$rc"


### PR DESCRIPTION
## What

Adds a **Docs CI** job (`ollama-model-drift`) that fetches the source-of-truth
`.env.ollama` from `rossoctl/examples` and asserts the weather demo doc
references the same `LLM_MODEL`. This catches the exact class of drift that was
fixed by hand in #2516 (C3).

Implements @huang195's suggestion from the #2516 review, scoped down to what's
actually buildable today.

## Why scoped to the weather demo only

While implementing the guard I found the drift is deeper than a stale string:
**only the weather service ships an `.env.ollama`** in `rossoctl/examples`. The
image / generic / file-organizer / slack demos all instruct users to import an
`.env.ollama` that **does not exist** in the examples repo, so there is nothing
to check them against yet.

| Demo doc | `.env.ollama` in examples repo? |
|---|---|
| weather | ✅ `a2a/weather_service/.env.ollama` → `LLM_MODEL=llama3.2:3b-instruct-fp16` |
| image / generic / file-organizer | ❌ only `.env.openai` |
| slack | ❌ no `.env.ollama`; `.env.template` has `TASK_MODEL_ID` (different var) |

Extending the guard to the other four is blocked on the examples repo
publishing those files (or the docs dropping the reference). Full breakdown and
tracking in #2527.

## Design notes

- Follows the existing `docs-ci.yaml` gating/advisory convention.
- **Real drift** (script exit 1) **fails** the job.
- A **source-fetch failure** (exit 2, e.g. transient `raw.githubusercontent.com`
  flake) is **advisory** — it warns but does not fail, so this repo's CI does not
  go red on another repo's/CDN's momentary unavailability. This directly answers
  the cross-repo-coupling / network-flake tradeoff @huang195 flagged.
- Fetch has a 3-try retry with backoff.

## Testing

- Pre-C3 doc (`gpt-oss:latest`) → script exits 1, drift detected ✅
- Post-C3 doc (`llama3.2:3b-instruct-fp16`) → script exits 0, in sync ✅
- `bash -n` clean; YAML validated.

Layers cleanly on top of the now-merged C3 (#2516).

Refs: #2527
Assisted-By: Claude Code
