### PR TITLE
docs: Rename rossoctl install and emphasize abctl install

### DIFF
--- a/docs/getting-started/install-cli.md
+++ b/docs/getting-started/install-cli.md
@@ -1,7 +1,7 @@
 ---
-title: Install the CLI
+title: Install the cluster CLI
 description: Test agents and administer with a command line
-sidebar_label: Install the CLI
+sidebar_label: Install the cluster CLI
 sidebar_position: 60
 ---
 

--- a/docs/getting-started/install-local.md
+++ b/docs/getting-started/install-local.md
@@ -1,47 +1,66 @@
 ---
 title: Install for laptop
 description: CLI and RossoCortex guide.
-sidebar_label: Install for laptop
+sidebar_label: Install Cortex for laptop
 sidebar_position: 20
 ---
 
-:::tip
+<!-- 
+  This is derived from https://github.com/rossoctl/cortex/blob/main/README.md
+  Keep this updated as that file changes.
+  Replace relative links in that file with GitHub links.
+-->
 
-Check back in early August for the quickstart guide for local rossoctl without Kubernetes. For now, here is a Context Guru example without Kubernetes or Docker
+**See what your coding agent actually sends — and pay less for it.**
 
-:::
+Cortex sits in your agent's request path, decrypts its traffic, and shows you the model
+calls, tool calls and agent-to-agent messages as they happen. It can also strip the
+tool definitions your agent never calls, which is 4–20% of the prompt on every turn.
 
-### First, obtain Cortex source code
+One binary, no Kubernetes. macOS or Linux, amd64 or arm64.
 
-```bash
-git clone git@github.com:rossoctl/cortex.git
-cd cortex/authbridge/cmd/authbridge-proxy
+## Quick start
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
+  | sh -s -- --claude-code
 ```
 
-### Then, run Cortex with AuthBridge + ContextGuru
+It asks before changing your Claude Code settings, then runs Cortex as a background
+service that survives crashes and logins.
 
-```bash
-LOG_LEVEL=debug go run -tags include_plugin_contextguru . --config ../../demos/context-guru/context-guru-tls-bridge.yaml
+Then open two terminals:
+
+```sh
+abctl observe   # the viewer
+claude          # as usual — no environment variables to set
 ```
 
-### Finally, run Claude against LiteLLM through AuthBridge
+Your agent's calls stream into `abctl`. Cortex only reads them; nothing is rewritten.
 
-Do this in a separate window.
+- **[Cut token cost](https://github.com/rossoctl/cortex/blob/main/authbridge/docs/laptop-token-savings.md)** — one more command
+- **[Start, stop, remove](https://github.com/rossoctl/cortex/blob/main/authbridge/docs/laptop-service.md)** — `abctl service status | start | stop`
+- **[Run it in Kubernetes](https://github.com/rossoctl/cortex/blob/main/authbridge/docs/kubernetes.md)** — sidecars, Keycloak, SPIFFE/SPIRE
 
-```bash
-NODE_EXTRA_CA_CERTS=/tmp/tls-bridge-ca/ca.crt HTTPS_PROXY=http://localhost:8081 claude
-```
+**Any agent works**, not only Claude Code: point it at `localhost:47600` and trust
+`~/.cortex/ca/ca.crt`.
 
-At this point, ask Claude `what is 2+2?` and see log messages from Context Guru.
+The install URL is on `main`, but the script re-runs the copy from the newest
+**release**, so `curl | sh` does not execute unreleased code. `--ref` overrides that.
 
----
+## What else Cortex does
 
-For the full demo, with
+Traffic visibility is the part you can use in a minute. The same binary provides the
+platform services agentic workloads need in production, as a sidecar or standalone:
 
-```
-export CG_MODEL_BASE=https://api.openai.com
-export CG_MODEL_NAME=gpt-4o-mini
-export CG_MODEL_KEY=...
-```
+- **Identity & access** — a verifiable identity per workload, and the right credentials
+  for each downstream call, so an agent never holds a tool's secret. This layer is
+  **AuthBridge**.
+- **Guardrails** — block agent actions that stray from the user's intent or aren't
+  grounded in the conversation.
+- **Egress control** — govern which external services a workload can reach.
+- **Cost controls** — trim the context a workload sends, and cap its spend.
 
-see https://github.com/rossoctl/cortex/tree/main/authbridge/demos/context-guru
+Everything is a plugin in one pipeline; the [plugin catalog](https://github.com/rossoctl/cortex/blob/main/authbridge/docs/plugin-catalog.md)
+lists what ships, and the [architecture reference](https://github.com/rossoctl/cortex/blob/main/authbridge/README.md) explains how
+a request flows through it.


### PR DESCRIPTION
## What & why

The web site did not show how to install _abctl_ and related Cortex things.
The web site did not make it clear that we should use _abctl_ instead of _rossoctl authbridge_.

## Acceptance tier

<!-- Pick one. When in doubt, go up a tier. See FEATURE_ACCEPTANCE.md. -->

- [x] Tier 0 — Maintenance (bugfix / docs / dependency bump / no-behavior refactor)
- [ ] Tier 1 — Standard feature (net-new user-facing behavior)
- [ ] Tier 2 — Large / contested feature (new subsystem, cross-repo, high-risk, or disputed value)

## Checklist

Complete the items for your tier. See [FEATURE_ACCEPTANCE.md](../FEATURE_ACCEPTANCE.md).

### Pillar 1 — Code quality (all tiers)

- [x] `make lint` and pre-commit pass
- [ n/a] Tests added/updated and passing
- [ n/a] Follows repo conventions
- [x] DCO sign-off on all commits (`git commit -s`)
- [ n/a] (Tier 1+) Behind a feature flag, off by default

### Pillar 2 — Documentation (all tiers; scope scales)

- [n/a] Docs affected by this change are updated
- [ n/a] (Tier 1+) User docs, config/dev docs, and feature-flag docs updated
- [ n/a] (Tier 2) Linked design doc / spec

cc @huang195 