### PR TITLE
docs: Add readme for data governance

### DIFF
--- a/docs/data-governance/README.md
+++ b/docs/data-governance/README.md
@@ -1,3 +1,7 @@
+---
+draft: true       # excluded from https://www.rossoctl.dev/
+---
+
 # Data Governance
 
 ## Executive Summary
@@ -5,10 +9,7 @@
 The Data Governance service provides a comprehensive solution for data visibility, risk, policies and enforcement across the platform. It delivers comprehensive, data-aware governance, risk assessment and enforcement capabilities natively within the platform, ensuring secure data lifecycles and robust risk mitigation across complex AI agent ecosystems.
 
 
-## Overview
-Data-Aware Governance & Security for Agentic Platforms to deliver comprehensive, data-aware governance and security capabilities natively within the platform, ensuring secure data lifecycles and robust risk mitigation across complex AI agent ecosystems.
-
-Core Capabilities & Strategic Pillars:
+## Core Capabilities & Strategic Pillars:
 
 - Traceability at Scale (Collection & Enrichment)
 Systematically collect, classify, and enrich data flow traces across the entire agentic platform to establish complete, scalable observability.
@@ -20,11 +21,11 @@ Deploy sophisticated data flow analysis technology capable of monitoring multipl
 Implement robust Data Barriers designed to enforce strict, policy-driven dataflow constraints. These barriers will operate autonomously to govern the entire data lifecycle, specifically controlling how information is accessed, transformed, and retained within the system.
 
 ## Current scope
-Lineage plugin - collects events from cortex.
-Data Governance pod - computes interactions and entities from raw spans.
-Data Classification - classification of payloads for known personal/confidential data types.
-Observability - Execution flow graph
-Loosely coupled UI dashboard (linked from within the main rosso UI, under Observability)
+- Lineage plugin - collects events from cortex.
+- Data Governance pod - computes interactions and entities from raw spans.
+- Data Classification - classification of payloads for known personal/confidential data types.
+- Observability - Execution flow graph
+- Loosely coupled UI dashboard (linked from within the main rosso UI, under Observability)
 
 
 ## Installing and running

--- a/docs/data-governance/README.md
+++ b/docs/data-governance/README.md
@@ -1,0 +1,32 @@
+# Data Governance
+
+## Executive Summary
+
+The Data Governance service provides a comprehensive solution for data visibility, risk, policies and enforcement across the platform. It delivers comprehensive, data-aware governance, risk assessment and enforcement capabilities natively within the platform, ensuring secure data lifecycles and robust risk mitigation across complex AI agent ecosystems.
+
+
+## Overview
+Data-Aware Governance & Security for Agentic Platforms to deliver comprehensive, data-aware governance and security capabilities natively within the platform, ensuring secure data lifecycles and robust risk mitigation across complex AI agent ecosystems.
+
+Core Capabilities & Strategic Pillars:
+
+- Traceability at Scale (Collection & Enrichment)
+Systematically collect, classify, and enrich data flow traces across the entire agentic platform to establish complete, scalable observability.
+
+- Advanced Threat Detection (Analysis & Monitoring)
+Deploy sophisticated data flow analysis technology capable of monitoring multiple agent trajectories and sessions. This continuous analysis operates over configurable time windows to proactively detect and mitigate critical risks, specifically targeting potential data breaches and data corruption.
+
+- Autonomous Policy Enforcement (Data Barriers)
+Implement robust Data Barriers designed to enforce strict, policy-driven dataflow constraints. These barriers will operate autonomously to govern the entire data lifecycle, specifically controlling how information is accessed, transformed, and retained within the system.
+
+## Current scope
+Lineage plugin - collects events from cortex.
+Data Governance pod - computes interactions and entities from raw spans.
+Data Classification - classification of payloads for known personal/confidential data types.
+Observability - Execution flow graph
+Loosely coupled UI dashboard (linked from within the main rosso UI, under Observability)
+
+
+## Installing and running
+
+See: https://github.com/rossoctl/lab-data-governance/tree/v0.8


### PR DESCRIPTION
## What & why

Introducing the first version of the data governance service, that enables data visibility, risk, policies and enforcement across the platform. 
This PR is a doc only, required code is already pushed to either https://github.com/rossoctl/cortex or https://github.com/rossoctl/lab-data-governance.

Closes #2274 

## Acceptance tier

<!-- Pick one. When in doubt, go up a tier. See FEATURE_ACCEPTANCE.md. -->

- [X] Tier 0 — Maintenance (docs)
- [] Tier 1 — Standard feature (net-new user-facing behavior)
- [ ] Tier 2 — Large / contested feature (new subsystem, cross-repo, high-risk, or disputed value)

## Checklist

Complete the items for your tier. See [FEATURE_ACCEPTANCE.md](../FEATURE_ACCEPTANCE.md).

### Pillar 1 — Code quality (all tiers)

- [ ] `make lint` and pre-commit pass
- [ ] Tests added/updated and passing
- [X] Follows repo conventions
- [X] DCO sign-off on all commits (`git commit -s`)
- [ ] (Tier 1+) Behind a feature flag, off by default

### Pillar 2 — Documentation (all tiers; scope scales)

- [X] Docs affected by this change are updated
- [X] (Tier 1+) User docs, config/dev docs, and feature-flag docs updated
- [ ] (Tier 2) Linked design doc / spec

### Pillar 3 — Real value (Tier 1+)

- [ ] Names a persona/use-case, the problem, and evidence of demand
- [X] Maps to an epic / roadmap Key Result (or justifies opportunistic value)
- [X] **Working demo + example provided, runs in local Kind** (mandatory)
- [ ] (Tier 2) Value scorecard: Impact \_\_/5 · Reach \_\_/5 · Effort \_\_/5 · Fit \_\_/5

### Pillar 4 — Environment portability (Tier 1+)

- [] Passes the baseline local Kind + laptop loop (`kind-full-test.sh`)
- [ ] Declares status for other environments below

| Environment | Supported / Not-supported / Untested | Note |
|-------------|--------------------------------------|------|
| HyperShift  |                                      |      |
| OpenShift   |                                      |      |
| Cloud       |                                      |      |
| Sandbox     |                                      |      |
