### PR TITLE
docs: Cortex laptop observability — read the numbers, first-run path, troubleshooting

### DIFF
--- a/docs/concepts/core/cortex.md
+++ b/docs/concepts/core/cortex.md
@@ -99,6 +99,9 @@ when the decision layer changes.
 
 ## Related pages
 
+- [Quickstart on a laptop](../../get-started/laptop.md) runs RossoCortex as one program on your computer.
+- [Read the numbers](../../get-started/reading-the-numbers.md) explains the token counts, the cost and
+  the latency that RossoCortex captures.
 - [Identity and trust](identity.md) explains where the identities come from.
 - [AuthBridge](../../security/authbridge.md) describes the two default plugins.
 - [Authentication flows](../../security/flows.md) contains the diagrams.

--- a/docs/concepts/experiments/context-compaction.md
+++ b/docs/concepts/experiments/context-compaction.md
@@ -90,6 +90,13 @@ rossoctl authbridge exec \
 
 See [Quickstart on a laptop](../../get-started/laptop.md).
 
+## What you see for it
+
+The observe mode records the reduction that the plugin can make, so you can measure the benefit
+before you accept the risk. On a laptop, `abctl observe` shows the tokens and the cost that the
+plugin removed for each session. See
+[Read the pruning savings](../../get-started/reading-the-numbers.md#read-the-pruning-savings).
+
 ## Try it
 
 The [context compaction demonstration](https://github.com/rossoctl/cortex/tree/main/authbridge/demos/context-guru)
@@ -97,5 +104,6 @@ contains the finance example from the table above.
 
 ## Related pages
 
+- [Read the numbers](../../get-started/reading-the-numbers.md) shows the saving that the plugin made.
 - [Cost control](cost-control.md) gives a smaller reduction with less risk.
 - [context-guru](https://github.com/rossoctl/context-guru) is the engine.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -34,6 +34,7 @@ repository as core or experimental.
 | Agent deployment and discovery | Ready | [Control plane](core/control-plane.md) |
 | The data plane proxy | Ready | [RossoCortex](core/cortex.md) |
 | Traces and network data | Ready | [Observability](../operate/observability.md) |
+| Token counts, cost and latency on a laptop | Ready | [Read the numbers](../get-started/reading-the-numbers.md) |
 
 ## Experimental features
 

--- a/docs/get-started/cli.md
+++ b/docs/get-started/cli.md
@@ -2,7 +2,7 @@
 title: Install the cluster CLI
 sidebar_label: Install the cluster CLI
 description: Install rossoctl, the CLI for a cluster, and run the first commands.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 The `rossoctl` command does the tasks that the console does, for a cluster. It also runs a local

--- a/docs/get-started/configure-a-model.md
+++ b/docs/get-started/configure-a-model.md
@@ -1,7 +1,7 @@
 ---
 title: Configure a model
 description: Give an agent a local model or a model from a cloud provider.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 A Rossoctl agent operates with any model endpoint that is compatible with the OpenAI interface. You do

--- a/docs/get-started/first-agent.md
+++ b/docs/get-started/first-agent.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy your first agent
 description: Deploy the sample weather agent and send a message to it.
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 This procedure deploys an agent from a container image, and then sends a message to the agent. Complete

--- a/docs/get-started/first-tool.md
+++ b/docs/get-started/first-tool.md
@@ -1,7 +1,7 @@
 ---
 title: Connect your first tool
 description: Deploy an MCP tool and let an agent call it.
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 A tool gives an agent the ability to do work. A Rossoctl tool is a container that uses the

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -17,7 +17,8 @@ The program shows the model calls, the tool calls and the agent messages that yo
 Choose this path if you want to see how Rossoctl works before you install the full platform. Choose
 it also if you want to reduce the token cost of an agent.
 
-Go to [Quickstart on a laptop](laptop.md).
+Go to [Quickstart on a laptop](laptop.md). Then read [Read the numbers](reading-the-numbers.md) to
+learn what the program shows you.
 
 ## Quickstart on Kubernetes
 

--- a/docs/get-started/kubernetes.md
+++ b/docs/get-started/kubernetes.md
@@ -2,7 +2,7 @@
 title: Quickstart on Kubernetes
 sidebar_label: Quickstart — Kubernetes
 description: Install Rossoctl on a local Kind cluster and open the console.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 This procedure installs Rossoctl on a local [Kind](https://kind.sigs.k8s.io) cluster. The installation

--- a/docs/get-started/laptop.md
+++ b/docs/get-started/laptop.md
@@ -108,3 +108,10 @@ See [Install the cluster CLI](cli.md).
   [Context compaction](../concepts/experiments/context-compaction.md).
 - To understand the program that you installed, read [RossoCortex](../concepts/core/cortex.md).
 - To get deployment, discovery and the web console, read [Quickstart on Kubernetes](kubernetes.md).
+
+## Give feedback
+
+Cortex on a laptop is new. If something did not work, or the install was not clear, tell us. Open the
+**Laptop feedback** form on
+[rossoctl/cortex](https://github.com/rossoctl/cortex/issues/new/choose), or write a message in
+[Slack](https://ibm.biz/rossoctl-slack).

--- a/docs/get-started/laptop.md
+++ b/docs/get-started/laptop.md
@@ -8,6 +8,8 @@ sidebar_position: 2
 RossoCortex is the data plane of Rossoctl. It runs as one program on macOS or Linux. It is a proxy on the request path of your agent. It shows each model call, each tool call and each
 agent message as it happens. You do not need Kubernetes.
 
+The traffic stays on your computer. RossoCortex does not send it to Rossoctl or to any other service.
+
 This procedure needs approximately 5 minutes.
 
 ## Before you start
@@ -51,8 +53,17 @@ claude
 Use Claude Code in the normal way. There is no environment variable to set. The calls of the agent
 appear in `abctl`.
 
+In `abctl observe`, press `Enter` on a session to see its events. Press `Enter` on an event to see
+its full content. Press `/` to filter the events by a substring match on the method. Press `q` to
+quit.
+
 RossoCortex reads this traffic. It does not change the traffic until you enable a plugin that changes
 it.
+
+## Step 3: read the numbers
+
+Each session shows a token count and a cost. To learn what each number means, and how to act on it,
+read [Read the numbers](reading-the-numbers.md).
 
 ## Manage the service
 
@@ -61,6 +72,14 @@ abctl service status
 abctl service stop
 abctl service start
 ```
+
+## Stop and remove
+
+To stop the traffic for one session, quit `abctl observe` with `q` and stop your agent. RossoCortex
+continues to run as a background service.
+
+To stop the service, and to remove it, read [Manage the service](#manage-the-service). The service
+holds no traffic after a stop. It reads traffic again after you start it.
 
 ## Other agents
 
@@ -82,6 +101,7 @@ See [Install the cluster CLI](cli.md).
 
 ## Next
 
+- To understand the numbers that `abctl observe` shows, read [Read the numbers](reading-the-numbers.md).
 - To reduce the token cost of your agent, read
   [Cost control](../concepts/experiments/cost-control.md).
 - To make large tool output smaller, read

--- a/docs/get-started/reading-the-numbers.md
+++ b/docs/get-started/reading-the-numbers.md
@@ -199,6 +199,13 @@ One session is useful. A week of sessions is more useful. The value is in the ch
 You see these only if Cortex runs while you work. It runs as a background service and adds no step to
 your day. See [Manage the service](laptop.md#manage-the-service).
 
+## Give feedback
+
+Did the numbers tell you what you needed, or not? Was a figure confusing? Tell us. Open the **Laptop
+feedback** form on [rossoctl/cortex](https://github.com/rossoctl/cortex/issues/new/choose), or write a
+message in [Slack](https://ibm.biz/rossoctl-slack). Feedback on the local tool is what makes the next
+release clearer.
+
 ## Related pages
 
 - [Quickstart on a laptop](laptop.md) installs Cortex and starts `abctl observe`.

--- a/docs/get-started/reading-the-numbers.md
+++ b/docs/get-started/reading-the-numbers.md
@@ -1,0 +1,208 @@
+---
+title: Read the numbers
+sidebar_label: Read the numbers
+description: What Cortex shows for each session, what each number means, and how to act on it.
+sidebar_position: 3
+---
+
+You installed Cortex and started `abctl observe`. Now you see traffic. This page explains what the
+numbers mean and what to do with them.
+
+Cortex shows you what your coding agent sent and what it cost. It shows the model calls, the tool
+calls and the token counts for each session, on your own computer, as they happen. Your agent does
+not report this. Your model provider reports a monthly total, not one session while you work. Cortex
+is the view between the two.
+
+:::note The data stays on your computer
+Cortex captures this traffic on your computer and keeps it there. It does not collect the data and it
+does not send the data to Rossoctl or to any other service. The data is for you to read and to inspect.
+When you stop the service, the data goes with it. See [Manage the service](laptop.md#manage-the-service).
+:::
+
+<!-- VERIFY v0.9.0: confirm the local-only claim once persistence (#901, sqlite) lands — the store is
+     on-disk and local, and no telemetry is sent by default. Central reporting is a separate, opt-in
+     feature (#898), not part of the laptop tool. -->
+
+
+<!-- VERIFY v0.9.0: the metrics view, the token/cost/latency figures and the pruning figure depend
+     on #950, #951 and #952. Confirm the field names, the labels and the layout against `abctl
+     observe` from a v0.9.0 binary before release, and replace the worked example below with a
+     captured session. -->
+
+## What the numbers tell you
+
+The numbers support four decisions:
+
+- **Find an expensive prompt.** One session that costs much more than the others shows you where the
+  cost is.
+- **See whether caching operates.** A high cache-read count means the model reuses your prompt. A low
+  count means it does not, and you pay the full rate each turn.
+- **Catch a session that does not end.** A token count that grows without a result is an agent in a
+  loop. You stop it before it costs more.
+- **Decide whether to prune tool definitions.** The pruning figure shows the tokens that Cortex
+  removed, so you know if the feature is worth enabling. See [Cost control](../concepts/experiments/cost-control.md).
+
+You can read this page before you install Cortex. It describes what Cortex shows you that you cannot
+otherwise see.
+
+## Watch a session
+
+`abctl observe` opens a terminal interface. It has three views.
+
+- **Sessions.** A list of the sessions, with the most recent one first. Each row shows the identifier,
+  the time of the last event, the event count and the token total.
+- **Events.** The calls in one session. Each row shows the time, the direction, the protocol, the
+  model or the method, the status, the duration and the host. Press `Enter` on a session to open it.
+- **Detail.** The full content of one event, as formatted JSON. Press `Enter` on an event to open it.
+
+### Keys
+
+| Key | Action |
+| --- | --- |
+| `↑` `↓` or `k` `j` | Move between rows |
+| `Enter` | Open the selected row |
+| `Esc` | Return to the previous view |
+| `/` | Filter the events |
+| `p` | Pause and resume the stream |
+| `y` | Write the event to a file in `/tmp` |
+| `g` `G` | Move to the top or the bottom |
+| `q` or `Ctrl+C` | Quit |
+
+The `/` key filters the events by a **substring match on the method**. For example, `messages` shows
+only the events whose method contains that text. It is a text match on the method, not a query
+language. You cannot filter on a condition such as a duration.
+
+## Read the tokens
+
+A model call has a cost in tokens. Cortex separates the tokens into five categories, because each
+category has a different price.
+
+| Category | What it is | Why it is separate |
+| --- | --- | --- |
+| **Input** | The prompt tokens that the model read for the first time | You pay the full rate for these. |
+| **Cache read** | The prompt tokens that the model read from its cache | Much less than the input rate. This is caching that operates. |
+| **Cache write** | The prompt tokens that the model wrote to its cache | More than the input rate. This is the one-time cost to store the prompt. |
+| **Output** | The tokens that the model generated | |
+| **Reasoning** | The output tokens that the model used to reason | A part of the output on some models. |
+
+### Why cache read and cache write are two numbers
+
+A model can cache a part of your prompt. The next call that sends the same part reads it from the
+cache. This is useful for a coding agent, because the agent sends the same system prompt and the same
+files on each turn.
+
+The two cache numbers have different prices, so Cortex keeps them apart:
+
+- **A cache write costs more than an input token.** You pay a premium once, to store the prompt.
+- **A cache read costs a fraction of an input token.** You save on each later turn that reuses the
+  prompt.
+
+The split tells you whether caching earns its cost:
+
+- A large **cache-read** count means the cache operates. You pay the low rate for most of the prompt.
+- A **cache-write** count that repeats, with little cache-read, means the cache does not hold. You pay
+  the premium again and again and get no saving. This happens when the prompt changes on each turn.
+
+## Read the cost
+
+Cortex applies a price to each token category and adds the results. The figure is the cost of the
+session.
+
+- **The cost is an estimate, unless the provider returns an exact figure.** Cortex computes the cost
+  from published rates for each model. When the provider returns an exact cost (for example, the
+  `x-litellm-response-cost` header from LiteLLM), Cortex uses that figure instead.
+- **The rates come from a table for each model.** A model that Cortex does not recognize has no rate,
+  so its cost is zero even when its token counts are correct.
+
+<!-- VERIFY v0.9.0: confirm the rate source (built-in table vs. config), and the exact provider
+     headers Cortex reads for an authoritative cost, once #950/#952 land. -->
+
+## Read the latency
+
+Cortex records two times for each model call.
+
+- **Time to first token.** The time from the request to the first part of the reply. For a reply that
+  streams, this is the time until you see the first word. It is the number that decides how fast the
+  agent feels.
+- **Total response time.** The time from the request to the last part of the reply. It depends on the
+  length of the reply.
+
+For a set of calls, Cortex reports percentiles.
+
+- **p50** is the middle value. Half of the calls are faster. It is the typical experience.
+- **p95** and **p99** are the slow calls. Ninety-five or ninety-nine percent of the calls are faster.
+  These are the calls that a user notices. A p50 that is good with a p99 that is bad means that most
+  calls are fast, but the slow calls are very slow.
+
+## Read the pruning savings
+
+If you enable tool pruning, Cortex removes the tool definitions that the agent does not use, before
+the request goes to the model. The savings figure is the tokens and the cost that the pruning
+removed. See [Cost control](../concepts/experiments/cost-control.md).
+
+- **A figure above zero** is the saving for that session. You paid less because Cortex sent a smaller
+  request.
+- **A figure of zero** means that Cortex removed nothing. The usual cause is an agent with no tools.
+  An agent that sends no tool definitions has nothing to prune, so zero is the correct figure and not
+  a failure.
+
+This figure is the answer to one question: what does pruning do for me? You enable pruning, you read
+the figure, and you decide if the saving is worth the feature.
+
+## A worked example
+
+:::note
+These are representative figures for the data that Cortex captures. They show the shape of a real
+session. Replace them with a session that you capture before you rely on the exact values.
+:::
+
+<!-- VERIFY v0.9.0: replace this table with a real `abctl observe` capture from a v0.9.0 binary. -->
+
+One session of a coding agent, with tool pruning enabled:
+
+| Field | Value |
+| --- | --- |
+| Model | `claude-sonnet-4` |
+| Events | 34 |
+| Input tokens | 12,400 |
+| Cache read | 486,000 |
+| Cache write | 61,200 |
+| Output tokens | 8,900 |
+| Reasoning tokens | 3,100 |
+| Cost | 2.14 USD |
+| Time to first token (p50) | 0.7 s |
+| Time to first token (p95) | 2.9 s |
+| Total response time (p95) | 24 s |
+| Tokens pruned | 41,000 |
+| Cost saved by pruning | 0.12 USD |
+
+How to read it:
+
+- **Caching operates.** The cache-read count (486,000) is much larger than the input count (12,400).
+  The agent sends the same context on each turn, and the model reads almost all of it from the cache.
+  Without the cache, the input cost is many times higher.
+- **The cache-write count is a one-time cost.** The 61,200 cache-write tokens are the first turn that
+  stored the context. Later turns read it, and do not write it again.
+- **The slow tail is visible.** The typical first token arrives in 0.7 s, but the slowest calls take
+  2.9 s. If the agent felt slow, the p95 is the reason, not the p50.
+- **Pruning earns a small amount here.** It saved 0.12 USD, because it removed 41,000 tokens of unused
+  tool definitions across the session. On an agent with many tools, this figure is larger.
+
+## Why leave Cortex running
+
+One session is useful. A week of sessions is more useful. The value is in the change over time:
+
+- A prompt that grows more expensive each day.
+- A cache-read count that falls, because a change to the agent broke the cache.
+- A session that costs ten times the others.
+
+You see these only if Cortex runs while you work. It runs as a background service and adds no step to
+your day. See [Manage the service](laptop.md#manage-the-service).
+
+## Related pages
+
+- [Quickstart on a laptop](laptop.md) installs Cortex and starts `abctl observe`.
+- [Cost control](../concepts/experiments/cost-control.md) reduces the token cost.
+- [Context compaction](../concepts/experiments/context-compaction.md) makes large tool output smaller.
+- [Troubleshooting](../operate/troubleshooting.md) covers the case of no events or wrong numbers.
+- [RossoCortex](../concepts/core/cortex.md) explains the program that captures this data.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ code, if the agent uses the [A2A protocol](https://a2a-protocol.org/latest/).
 | Your goal | Start here | Time |
 | --- | --- | --- |
 | See the model calls and tool calls that your agent makes | [Quickstart on a laptop](get-started/laptop.md) | 5 minutes |
+| Understand the token counts and the cost of a session | [Read the numbers](get-started/reading-the-numbers.md) | — |
 | Run the platform and deploy an agent | [Quickstart on Kubernetes](get-started/kubernetes.md) | 20 minutes |
 | Put your own agent on the platform | [Bring your own agent](workloads/bring-your-own-agent.md) | — |
 | Review the security model | [Security](security/index.md) | — |

--- a/docs/operate/observability.md
+++ b/docs/operate/observability.md
@@ -100,8 +100,9 @@ that no person expected.
 The `--with-kiali` option installs Prometheus, which collects the standard metrics of each workload.
 
 For the token cost, RossoCortex is the source, because each model call passes through it. On your
-computer, `abctl observe` shows the cost as it happens. In a cluster, the budget plugins record and limit the
-cost. See [Cost control](../concepts/experiments/cost-control.md).
+computer, `abctl observe` shows the cost as it happens; to read those numbers, see
+[Read the numbers](../get-started/reading-the-numbers.md). In a cluster, the budget plugins record and
+limit the cost. See [Cost control](../concepts/experiments/cost-control.md).
 
 ## Confirm that the traces operate
 

--- a/docs/operate/troubleshooting.md
+++ b/docs/operate/troubleshooting.md
@@ -4,13 +4,130 @@ description: The failures that occur most often, and the recovery for each one.
 sidebar_position: 6
 ---
 
-This page groups each failure by the time at which it occurs. If your condition is not here, ask in
+This page has two parts. The first part is the laptop install of Cortex. The second part is the
+Kubernetes platform. If your condition is not here, ask in
 [Slack](https://ibm.biz/rossoctl-slack), or open an issue on
 [rossoctl/rossoctl](https://github.com/rossoctl/rossoctl/issues).
 
-## During the installation
+## On a laptop
 
-### The installation reports "exceeded its progress deadline"
+These conditions occur with the laptop install from
+[Quickstart on a laptop](../get-started/laptop.md). You do not need a Kubernetes cluster for this
+part.
+
+<!-- VERIFY v0.9.0: confirm the CA path, the service commands, the log path and the port against a
+     v0.9.0 install. The laptop install (install.sh, abctl service, the launchd/systemd units) is a
+     release target; see cortex#944 and cortex#945. -->
+
+### The certificate authority is not trusted
+
+Your agent reports a TLS error, or a certificate error, when it calls the model. The cause is that
+the agent does not trust the certificate of RossoCortex.
+
+Cortex writes its certificate authority to `~/.cortex/ca/ca.crt`. The `--claude-code` install
+configures Claude Code for you. For another agent, you set the certificate variable yourself. See
+[Other agents](../get-started/laptop.md#other-agents).
+
+To confirm the certificate, read it:
+
+```bash
+openssl x509 -in ~/.cortex/ca/ca.crt -noout -subject -dates
+```
+
+If the file is absent, the install did not complete. Run the install again.
+
+### The port 47600 is already in use
+
+The install or the service reports that the port is in use. RossoCortex listens on three loopback
+ports: 47600 for the proxy, 47601 for the session interface and 47602 for the statistics.
+
+Find the program that holds the port:
+
+```bash
+lsof -nP -iTCP@127.0.0.1:47600 -sTCP:LISTEN
+```
+
+If the program is a previous Cortex service, stop it with `abctl service stop`. If it is another
+program, stop that program, or change the ports of Cortex.
+
+### The service does not start, or starts and stops
+
+Read the status first:
+
+```bash
+abctl service status
+```
+
+On macOS, the service runs under `launchd`. On Linux, it runs under `systemd`. To read the service
+log:
+
+```bash
+# macOS
+log show --predicate 'process == "authbridge-proxy"' --last 10m
+
+# Linux
+journalctl --user -u cortex --since "10 minutes ago"
+```
+
+A service that starts and then stops usually has a port conflict, or a certificate that it cannot
+write. The log gives the cause.
+
+### Another program stopped working
+
+If `git`, `gh`, `ssh` or `curl` stops working after you install Cortex, the cause is a proxy or a
+certificate variable in your environment that sends other programs through Cortex.
+
+Cortex configures only your agent. It does not set a global proxy. Examine your shell profile and
+your environment for a `HTTP_PROXY`, `HTTPS_PROXY` or `NODE_EXTRA_CA_CERTS` value that you did not
+intend:
+
+```bash
+env | grep -iE "PROXY|CA_CERT|CA_BUNDLE|SSL_CERT"
+```
+
+Remove the value that is not correct, and open a new terminal. See the tool-compatibility work in
+cortex#946 and cortex#947.
+
+### No events appear, though the agent runs
+
+The agent runs, but `abctl observe` shows no events. Check each cause in order:
+
+1. **The service does not run.** Run `abctl service status`.
+2. **The agent does not use the proxy.** For an agent that is not Claude Code, confirm that you set
+   the proxy variable and the certificate variable. See
+   [Other agents](../get-started/laptop.md#other-agents).
+3. **The agent sends no traffic yet.** Send a message to the agent, and watch for the events.
+
+### The numbers are wrong or absent
+
+- **The token count is zero.** RossoCortex reads the token counts from the reply of the model. A
+  reply that Cortex cannot parse gives no counts. Confirm that the model is an OpenAI-compatible or an
+  Anthropic endpoint.
+- **The cost is zero, but the tokens are correct.** Cortex has no rate for that model. See
+  [Read the cost](../get-started/reading-the-numbers.md#read-the-cost).
+- **The pruning figure is zero.** The agent has no tool definitions to remove, or you did not enable
+  pruning. See [Read the pruning savings](../get-started/reading-the-numbers.md#read-the-pruning-savings).
+
+### Where the logs are, and what to attach to a bug report
+
+The service log is in the location that the service status reports. To attach a useful report to an
+issue, include:
+
+- The output of `abctl --version`.
+- The output of `abctl service status`.
+- Your operating system and your architecture (`uname -sm`).
+- The name of your agent, and the model.
+- The last part of the service log, with any secret removed.
+
+Open the issue on [rossoctl/cortex](https://github.com/rossoctl/cortex/issues).
+
+## On Kubernetes
+
+The rest of this page is the Kubernetes platform.
+
+### During the installation
+
+#### The installation reports "exceeded its progress deadline"
 
 The usual cause is a slow image download, and not a defect. Find the deployment that did not start, and
 run the installer again:
@@ -22,7 +139,7 @@ kubectl get deployments --all-namespaces
 Add the `--preload-images` option to the next installation. The script then downloads the images first,
 which avoids the rate limits of Docker Hub.
 
-### You use Podman and not Docker
+#### You use Podman and not Docker
 
 The installer needs a `docker` command on your path.
 
@@ -53,14 +170,14 @@ To delete the cluster and keep the Podman machine:
 kind delete cluster --name rossoctl
 ```
 
-### A build pod stays in `Pending` with `Insufficient cpu`
+#### A build pod stays in `Pending` with `Insufficient cpu`
 
 The node has insufficient CPU. The platform pods alone can request almost 4 CPUs.
 
 Give the runtime 6 CPUs and create the cluster again, or deploy each agent from an image and not from
 source. See [Machine size](index.md#machine-size).
 
-### The console shows an empty page on macOS
+#### The console shows an empty page on macOS
 
 If **Content & Privacy Restrictions** are active, the console can show an empty page. The setting is in
 System Settings, then Screen Time, then Content & Privacy Restrictions.
@@ -71,7 +188,7 @@ Disable the restrictions, and then restart the console:
 kubectl rollout restart -n rossoctl-system deployment rossoctl-ui
 ```
 
-### The SPIRE DaemonSets report 0 ready
+#### The SPIRE DaemonSets report 0 ready
 
 ```bash
 kubectl get daemonsets -n zero-trust-workload-identity-manager
@@ -80,9 +197,9 @@ kubectl get daemonsets -n zero-trust-workload-identity-manager
 No feature that needs a workload identity operates until these DaemonSets are ready. Examine the pods for
 a scheduling failure or an image download failure, and confirm that the node has capacity.
 
-## When you deploy an agent or a tool
+### When you deploy an agent or a tool
 
-### `Init:ErrImagePull` or `Init:ImagePullBackOff`
+#### `Init:ErrImagePull` or `Init:ImagePullBackOff`
 
 In almost all cases, your GitHub token is expired:
 
@@ -102,7 +219,7 @@ docker logout ghcr.io
 docker login ghcr.io -u <your-github-username>
 ```
 
-### You must change a value in `.secrets.yaml`
+#### You must change a value in `.secrets.yaml`
 
 The installer copies each secret into the namespaces. A change to the file is therefore not sufficient.
 Delete the Secret in each namespace that received it, and then run the installer again:
@@ -113,9 +230,9 @@ kubectl -n team1 delete secret github-token-secret
 scripts/kind/setup-rossoctl.sh
 ```
 
-## During operation
+### During operation
 
-### The chat page reports the status 503
+#### The chat page reports the status 503
 
 The console shows this message:
 
@@ -139,7 +256,7 @@ If the agent does not use Ollama, examine the model configuration of the agent:
 kubectl exec -n team1 <agent-pod> -- env | grep LLM_
 ```
 
-### A service stops responding
+#### A service stops responding
 
 This condition occurs with Keycloak and with the console. Restart the data plane:
 
@@ -148,7 +265,7 @@ kubectl rollout restart daemonset -n istio-system ztunnel
 kubectl rollout restart -n rossoctl-system deployment http-istio
 ```
 
-### A cluster returns 503 after you suspend the computer
+#### A cluster returns 503 after you suspend the computer
 
 **The condition.** Each address on `*.localtest.me:8080` returns the status 503 with the message
 `upstream connect error ... connection termination`. Each pod is in the `Running` state, the gateway
@@ -185,7 +302,7 @@ can also enable the `meshSelfHeal` feature flag, which adds a CronJob that does 
 data plane or create a new cluster. The cause is an upstream defect:
 [istio/ztunnel#1679](https://github.com/istio/ztunnel/issues/1679).
 
-### Keycloak reports a connection error to its database
+#### Keycloak reports a connection error to its database
 
 This condition occurs after the cluster runs for one day or longer. The cause is not completely
 understood. For the investigation, see
@@ -205,7 +322,7 @@ kubectl rollout restart -n rossoctl-system deployment rossoctl-ui
 
 You must then restart each agent, so that each agent gets its Keycloak client again.
 
-### The operator cannot authenticate to Keycloak
+#### The operator cannot authenticate to Keycloak
 
 This condition occurs after you change the administrator credentials. The operator holds the credentials
 in memory. Restart it:
@@ -222,7 +339,7 @@ POD=$(kubectl get pod -n rossoctl-system -l control-plane=controller-manager \
 kubectl logs -n rossoctl-system "$POD" -c manager | grep -i "keycloak\|auth" | tail -5
 ```
 
-### SPIFFE authentication reports an audience error or an issuer error
+#### SPIFFE authentication reports an audience error or an issuer error
 
 The `aud` claim of the identity document must be exactly `keycloak.publicUrl/realms/<realm>`. It must be
 the **external** address. Keycloak has the public address in its issuer configuration, and the check is a
@@ -231,7 +348,7 @@ comparison of two strings. The internal address of the service reaches the same 
 Examine the `keycloak.publicUrl` value in your Helm values. See
 [Authentication modes](../security/authentication-modes.md#the-audience-must-be-the-public-address).
 
-### The Skills entry does not appear in the console
+#### The Skills entry does not appear in the console
 
 The feature flag is not set. Enable it without a new installation:
 
@@ -247,7 +364,7 @@ kubectl logs -n rossoctl-system -l app.kubernetes.io/name=rossoctl-backend \
   | grep "skills routes registered"
 ```
 
-## Commands for diagnosis
+### Commands for diagnosis
 
 ```bash
 # Each pod that is not correct, in each namespace

--- a/docs/operate/troubleshooting.md
+++ b/docs/operate/troubleshooting.md
@@ -119,7 +119,9 @@ issue, include:
 - The name of your agent, and the model.
 - The last part of the service log, with any secret removed.
 
-Open the issue on [rossoctl/cortex](https://github.com/rossoctl/cortex/issues).
+Open the issue with the **Laptop feedback** form on
+[rossoctl/cortex](https://github.com/rossoctl/cortex/issues/new/choose). The form asks for each item
+in the list above.
 
 ## On Kubernetes
 


### PR DESCRIPTION
## What & why

Documentation for the **Cortex v0.9.0** laptop tool, the observability release ([rossoctl/cortex#962](https://github.com/rossoctl/cortex/issues/962)). It gives a first-time user, on their own workstation, everything needed to install Cortex, watch a session, and understand what the numbers mean and why the tool is worth leaving running. This backs the epic's **exit criterion 5** — a new user self-serves from the docs alone.

Written against the v0.9.0 target UX (`install.sh`, `abctl observe`, `abctl service`, tool pruning). Where a detail is not yet verifiable against a shipped binary, an HTML `VERIFY v0.9.0` comment marks it for the outside-reader check.

> **Draft.** #963 depends on the metrics work landing ([#950](https://github.com/rossoctl/cortex/issues/950), [#951](https://github.com/rossoctl/cortex/issues/951), [#952](https://github.com/rossoctl/cortex/issues/952)). This PR is ready for review of structure and voice now; the 5 `VERIFY v0.9.0` markers and the worked-example figures should be confirmed against a v0.9.0 binary before it leaves draft.

## Sub-issues addressed

| Issue | Where |
|---|---|
| [#963](https://github.com/rossoctl/cortex/issues/963) interpret metrics + value | New `get-started/reading-the-numbers.md` |
| [#959](https://github.com/rossoctl/cortex/issues/959) first-run path | `get-started/laptop.md` spine: install → observe → read → stop |
| [#960](https://github.com/rossoctl/cortex/issues/960) laptop troubleshooting | New "On a laptop" section in `operate/troubleshooting.md` |
| [#961](https://github.com/rossoctl/cortex/issues/961) separate laptop from Kubernetes | Laptop reader stays in `get-started/`; troubleshooting split laptop / Kubernetes |
| [#867](https://github.com/rossoctl/cortex/issues/867) explain the `/` filter | Documented inline in the abctl keys (substring match on METHOD, not a query language) |
| [#844](https://github.com/rossoctl/cortex/issues/844) Context Guru value | "What you see for it" + the pruning-savings section |

## The new page

`get-started/reading-the-numbers.md` covers:

- The value case, readable **before** installing, and a "the data stays on your computer" note — Cortex captures the traffic locally and sends it nowhere.
- The `abctl observe` views and keys, including the `/` filter.
- The five token categories, and **why cache-read and cache-write are priced apart**.
- How to read cost (estimated vs. authoritative), latency (TTFT vs. total, percentiles), and the tool-pruning savings, **including what a zero means**.
- A worked example on a representative session.

## Concepts extension

The new page is wired into `concepts/index.md` (a new Core row), the `RossoCortex` page, the `context-compaction` page, `observability.md`, and both landing pages. The get-started sidebar is renumbered to seat the new page after the laptop quickstart.

## Notes for reviewers

- The 5 `VERIFY v0.9.0` comments name the exact things to confirm against a shipped binary (install command, `abctl observe`/`service`, CA path, log paths, rate source, and the local-only claim relative to the opt-in central-collector feature [#898](https://github.com/rossoctl/cortex/issues/898)).
- The worked-example table uses representative figures from the real captured fields; it carries a note to replace it with a captured session before release.
- [#867](https://github.com/rossoctl/cortex/issues/867) also proposes renaming the TUI filter prompt to `METHOD name filter…`. That is a code change in `cortex`, out of scope here; the docs describe the current behaviour.

## Acceptance tier

- [x] Tier 0 — Maintenance (docs only)

## Checklist

- [x] Follows repo conventions; STE100 throughout
- [x] DCO sign-off; `Assisted-By` trailer, no `Co-Authored-By`
- [x] All internal links and heading anchors resolve
- [ ] `VERIFY v0.9.0` markers confirmed against a shipped binary (blocks leaving draft)

---

Assisted-By: Claude Code
